### PR TITLE
Fixing BI loadouts

### DIFF
--- a/hull3/assign/gear/Katiba_CSAT.h
+++ b/hull3/assign/gear/Katiba_CSAT.h
@@ -33,9 +33,9 @@ class Katiba_CSAT {
         uniformRadios[] = {"ACRE_PRC343"};
         vestRadios[] = {};
         backpackRadios[] = {};
-        uniformMedicalItems[] = {{"ACE_elasticBandage", 10}};
+        uniformMedicalItems[] = {{"ACE_elasticBandage", 6}};
         vestMedicalItems[] = {};
-        backpackMedicalItems[] = {};
+        backpackMedicalItems[] = {{"ACE_elasticBandage", 4}};
         code = "";
         headGear = "";
         uniform = "";

--- a/hull3/assign/gear/MX_NATO.h
+++ b/hull3/assign/gear/MX_NATO.h
@@ -33,9 +33,9 @@ class MX_NATO {
         uniformRadios[] = {"ACRE_PRC343"};
         vestRadios[] = {};
         backpackRadios[] = {};
-        uniformMedicalItems[] = {{"ACE_elasticBandage", 10}};
+        uniformMedicalItems[] = {{"ACE_elasticBandage", 6}};
         vestMedicalItems[] = {};
-        backpackMedicalItems[] = {};
+        backpackMedicalItems[] = {{"ACE_elasticBandage", 4}};
         code = "";
         headGear = "";
         uniform = "";

--- a/hull3/assign/gear/Mk20_AAF_DE.h
+++ b/hull3/assign/gear/Mk20_AAF_DE.h
@@ -33,9 +33,9 @@ class Mk20_AAF_DE {
         uniformRadios[] = {"ACRE_PRC343"};
         vestRadios[] = {};
         backpackRadios[] = {};
-        uniformMedicalItems[] = {{"ACE_elasticBandage", 10}};
+        uniformMedicalItems[] = {{"ACE_elasticBandage", 6}};
         vestMedicalItems[] = {};
-        backpackMedicalItems[] = {};
+        backpackMedicalItems[] = {{"ACE_elasticBandage", 4}};
         code = "";
         headGear = "";
         uniform = "";

--- a/hull3/assign/gear/Mk20_AAF_WD.h
+++ b/hull3/assign/gear/Mk20_AAF_WD.h
@@ -33,9 +33,9 @@ class Mk20_AAF_WD {
         uniformRadios[] = {"ACRE_PRC343"};
         vestRadios[] = {};
         backpackRadios[] = {};
-        uniformMedicalItems[] = {{"ACE_elasticBandage", 10}};
+        uniformMedicalItems[] = {{"ACE_elasticBandage", 6}};
         vestMedicalItems[] = {};
-        backpackMedicalItems[] = {};
+        backpackMedicalItems[] = {{"ACE_elasticBandage", 4}};
         code = "";
         headGear = "";
         uniform = "";

--- a/hull3/assign/gear/TRG_FIA.h
+++ b/hull3/assign/gear/TRG_FIA.h
@@ -33,9 +33,9 @@ class TRG_FIA {
         uniformRadios[] = {"ACRE_PRC343"};
         vestRadios[] = {};
         backpackRadios[] = {};
-        uniformMedicalItems[] = {{"ACE_elasticBandage", 10}};
+        uniformMedicalItems[] = {{"ACE_elasticBandage", 6}};
         vestMedicalItems[] = {};
-        backpackMedicalItems[] = {};
+        backpackMedicalItems[] = {{"ACE_elasticBandage", 4}};
         code = "";
         headGear = "";
         uniform = "";


### PR DESCRIPTION
NATO / AAF / CSAT have really low carry capacity in uniforms.

We've adjusted MNP to have decent space so should only effect these 4 that need a tweak.