### PR TITLE
Added message on player death, explaining the cause of death.

### DIFF
--- a/hull3/unit_functions.sqf
+++ b/hull3/unit_functions.sqf
@@ -83,6 +83,11 @@ hull3_unit_fnc_addFiredEHs = {
 hull3_unit_fnc_friendlyFireEH = {
     FUN_ARGS_5(_unit,_selectionName,_damage,_source,_projectile);
 
+    // Store the used projectile locally, for later use in hull3_unit_fnc_killMessage.
+    if (alive _unit) then {
+        _unit setVariable ["hull3_unit_lastProjectile", _projectile, false];
+    };
+
     if (_selectionName == "" && {_unit != _source} && {side _unit == side _source}) then {
         DECLARE(_message) = LOGGING_FORMAT("hull.unit.friendlyFire","WARN",FMT_4("'%1' dealt '%2' damage with '%3' to '%4'!",_source,_damage,_projectile,_unit));
         [_message] call hull3_common_fnc_logOnServer;
@@ -99,10 +104,79 @@ hull3_unit_fnc_killedEH = {
         [_message] call hull3_common_fnc_logOnServer;
     };
 
+    // Pass values on, for use in a message explaining how the player died.
+    _this spawn hull3_unit_fnc_killMessage;
+
     _unit removeEventHandler ["HandleDamage", _unit getVariable "hull3_eh_friendlyFire"];
     _unit removeEventHandler ["Killed", _unit getVariable "hull3_eh_killed"];
     _unit setVariable ["hull3_eh_friendlyFire", nil];
     _unit setVariable ["hull3_eh_killed", nil];
+};
+
+hull3_unit_fnc_ammoToString = {
+    FUN_ARGS_1(_projectile);
+
+    _text = switch(true) do 
+    {
+        // Bullet
+        case (_projectile isKindOf "BulletBase"): { "a bullet" };
+
+        // Rocket
+        case (_projectile isKindOf "RocketBase"): { "a rocket" };
+
+        // Missile
+        case (_projectile isKindOf "MissileBase"): { "a missile" };
+
+        // Mine
+        case ((_projectile isKindOf "MineBase") || (_projectile isKindOf "BoundingMineCore")): { "a mine" };
+
+        // GP
+        case (_projectile isKindOf "G_40mm_HE"): { "a rifle-propelled grenade" };
+
+        // Grenade
+        case (_projectile isKindOf "Grenade"): { "a grenade" };
+
+        // Bomb
+        case ((_projectile isKindOf "BombCore") || (_projectile isKindOf "TimeBombCore") || (_projectile isKindOf "DirectionalBombBase")): { "a bomb" };
+
+        // Vehicle
+        case (_projectile == ""): { "a vehicle" };
+
+        // Unknown
+        default {"something magical"};
+    };
+
+_projectile
+};
+
+hull3_unit_fnc_killMessage = {
+    FUN_ARGS_2(_unit,_killer);
+
+    // Fetch the name of the last projectile to hit the player.
+    _projectile = _unit getVariable ["STMF_DeathReport_LastDamage", "[no projectile found]"];
+    _text = [_projectile] call hull3_unit_fnc_ammoToString;
+
+    // If death was a road kill, add the vehicle type in brackets, rather than the ammo type
+    if(_text == "a vehicle") then {_projectile = typeOf (vehicle _killer)};
+
+    // Prepare message before we start the delay
+    _message = switch(true) do 
+    {
+        // If it's self-harm, it's probably physics or suicide.
+        case (_unit == _killer): { "You committed suicide, or were ARMA'd." };
+
+        // If the killer doesn't exist or is on sideUnknown, it's probably an explosion. Or a ghost.
+        case ((isNull _killer) || (side(group(_killer)) == sideUnknown)): { "You were killed by an exploding object." };
+
+        // If everything is normal, relay all kill details to the player.
+        default { format["You were killed by %1 from %2 metres away with %3 (%4), on team %5. You are on team %6.", name _killer, (round (_unit distance _killer)), _text, _projectile, side(group(_killer)), STMF_PlayerSide]; };
+    };
+
+    // Delay for player immersion
+    sleep 15;
+
+    // Output message to player
+    player globalChat _message;
 };
 
 hull3_unit_fnc_getAssignedTeam = {


### PR DESCRIPTION
Pretty self-explanatory. I have to store the last projectile to hit the player before they die using the existing HandleDamage event, which doesn't result in anything beyond a slight performance hit, and no network traffic. The projectile text is cleaned up to be human-readable with a switch statement, and there's a few special cases to deal with issues where ARMA does weird shit for the Killed handler.

Kami: do you want switch statements to use "if () exitWith" inside a call block still? I left it as a switch statement because I'm assigning a variable directly to the result, and it looks a bit cleaner.