### PR TITLE
Forcing reset of ACRE2 volume on init

### DIFF
--- a/hull3/acre_functions.sqf
+++ b/hull3/acre_functions.sqf
@@ -43,6 +43,7 @@ hull3_acre_fnc_acreInit = {
                     hull3_acre_isInitialized = true;
                     ["acre.initialized", [player]] call hull3_event_fnc_emitEvent;
                     [false] call acre_api_fnc_setSpectator;
+                    [1] call acre_api_fnc_setSelectableVoiceCurve;
                     DEBUG("hull.acre.spec","ACRE init finished.");
                 };
             };


### PR DESCRIPTION
Attempting to fix people being left on alternate speaking volumes from the previous mission.