### PR TITLE
Fixed incorrect breifing faction identifiers

### DIFF
--- a/hull3.Altis/hull3/briefing/civilian.sqf
+++ b/hull3.Altis/hull3/briefing/civilian.sqf
@@ -1,4 +1,4 @@
-// BLUFOR Notes
+// CIVFOR Notes
 
 // Situation
 player createDiaryRecord ["Diary", ["Situation","

--- a/hull3.Altis/hull3/briefing/indfor.sqf
+++ b/hull3.Altis/hull3/briefing/indfor.sqf
@@ -1,4 +1,4 @@
-// BLUFOR Notes
+// INDFOR Notes
 
 // Situation
 player createDiaryRecord ["Diary", ["Situation","

--- a/hull3.Altis/hull3/briefing/opfor.sqf
+++ b/hull3.Altis/hull3/briefing/opfor.sqf
@@ -1,4 +1,4 @@
-// BLUFOR Notes
+// OPFOR Notes
 
 // Situation
 player createDiaryRecord ["Diary", ["Situation","


### PR DESCRIPTION
With this fixed, compass will be able to print briefings correctly