### PR TITLE
Rehaul weapon safety to ignore launchers

### DIFF
--- a/hull3/mission_functions.sqf
+++ b/hull3/mission_functions.sqf
@@ -196,15 +196,17 @@ hull3_mission_fnc_clientSafetyTimerLoop = {
         [player] call hull3_unit_fnc_addFiredEHs;
         DEBUG("hull3.mission.safetytimer","Starting safety timer loop.");
         [{
-            DECLARE(_weapon) = primaryWeapon player;
-            if (!(_weapon in (player getVariable ["ace_safemode_safedWeapons", []]))) then {
-                [player, _weapon, _weapon] call ace_safemode_fnc_lockSafety;
+          {
+            if (!(_x in (player getVariable ["ace_safemode_safedWeapons", []]))) then {
+                [player, _x, _x] call ace_safemode_fnc_lockSafety;
             };
-            if ([] call hull3_mission_fnc_hasSafetyTimerEnded) then {
-                [_this select 1] call CBA_fnc_removePerFrameHandler;
-                player removeEventHandler ["Fired", player getVariable "hull3_eh_fired"];
-                DEBUG("hull3.mission.safetytimer","Safety timer has ended. Removed fired EH.");
-            };
+          } foreach [primaryWeapon player, handgunWeapon player];
+
+          if ([] call hull3_mission_fnc_hasSafetyTimerEnded) then {
+              [_this select 1] call CBA_fnc_removePerFrameHandler;
+              player removeEventHandler ["Fired", player getVariable "hull3_eh_fired"];
+              DEBUG("hull3.mission.safetytimer","Safety timer has ended. Removed fired EH.");
+          };
         }, 0, []] call CBA_fnc_addPerFrameHandler;
     };
 };

--- a/hull3/mission_functions.sqf
+++ b/hull3/mission_functions.sqf
@@ -196,7 +196,7 @@ hull3_mission_fnc_clientSafetyTimerLoop = {
         [player] call hull3_unit_fnc_addFiredEHs;
         DEBUG("hull3.mission.safetytimer","Starting safety timer loop.");
         [{
-            DECLARE(_weapon) = currentWeapon player;
+            DECLARE(_weapon) = primaryWeapon player;
             if (!(_weapon in (player getVariable ["ace_safemode_safedWeapons", []]))) then {
                 [player, _weapon, _weapon] call ace_safemode_fnc_lockSafety;
             };


### PR DESCRIPTION
As per title, removes weapon safety from launchers but keeps it from Rifles + Pistols. Rockets still removed if fired so shouldn't have any chance of spawn death.