### PR TITLE
Removing CUP_BAF_MTP from woodland

### DIFF
--- a/hull3/factions.h
+++ b/hull3/factions.h
@@ -890,7 +890,7 @@ class Faction {
         description = "Multicam DPM and L85's";
         languages[] = {{"west", 100}};
         side = "west";
-        camouflage[] = {"woodland", "desert"};
+        camouflage[] = {"desert"};
         rolePrefix = "BAF";
         vehicleClassnames[] = {
             {"CO", "CUP_B_LR_Transport_GB_D"},


### PR DESCRIPTION
As per https://github.com/kami-/hull3/issues/129