### PR TITLE
Adding setting for disabling ambient animals

### DIFF
--- a/hull3/hull3.h
+++ b/hull3/hull3.h
@@ -291,6 +291,7 @@ class Hull3 {
         BIS_noCoreConversations = 1;                    // Disables BIS unit conversations
         enableSaving = 0;                               // Enables game saving
         disableRemoteSensors = 1;                       // Disables RemoteSensors
+        enableEnvironment = 0;                          // Disables ambient animals but keeps sounds
     };
 
     class GarbageCollector {

--- a/hull3/settings_functions.sqf
+++ b/hull3/settings_functions.sqf
@@ -27,6 +27,10 @@ hull3_settings_fnc_setNonStandardGeneralSettings = {
         disableRemoteSensors true;
         DEBUG("hull3.settings","RemoteSensors are disabled.");
     };
+    if (!(["General", "enableEnvironment"] call hull3_config_fnc_getBool)) then {
+        enableEnvironment [false, true];
+        DEBUG("hull3.settings","Ambient animals are disabled.");
+    };
 };
 
 hull3_settings_fnc_setPlayerSettings = {


### PR DESCRIPTION
Disables ambient animals by default.

Wabbit hunting season is over.