### PR TITLE
Fixed Pilot uniform for AUS AMCU

### DIFF
--- a/hull3/assign/uniform/AUS_AMCU.h
+++ b/hull3/assign/uniform/AUS_AMCU.h
@@ -154,7 +154,6 @@ class AUS_AMCU {
 
     class P : Crew {
         headGear = "H_PilotHelmetHeli_O";
-        uniform = "U_B_HeliPilotCoveralls";
         vest = "V_TacVest_oli_ARM";
         backpack = "B_Parachute";
     };


### PR DESCRIPTION
Pilot had NATO uniform (with USA patches), removed to default back to crewman AMCU uniform.