### PR TITLE
Adding standardised bipods and scopes to M27s

### DIFF
--- a/hull3/assign/gear/HK416_CTRG_BLK.h
+++ b/hull3/assign/gear/HK416_CTRG_BLK.h
@@ -132,7 +132,7 @@ class HK416_CTRG_BLK {
 
     class AR : Rifleman {
         primaryWeapon = "arifle_SPAR_02_blk_F";
-        primaryWeaponItems[] = {"bipod_01_F_blk", "RH_SFM952V"};
+        primaryWeaponItems[] = {"optic_Holosight_blk_F", "RH_SFM952V", "RH_HBLM"};
         vestMagazines[] = {{"150Rnd_556x45_Drum_Mag_F", 2}};
         backpackMagazines[] = {
             {"150Rnd_556x45_Drum_Mag_F", 2},

--- a/hull3/assign/gear/HK416_CTRG_DE.h
+++ b/hull3/assign/gear/HK416_CTRG_DE.h
@@ -132,7 +132,7 @@ class HK416_CTRG_DE {
 
     class AR : Rifleman {
         primaryWeapon = "arifle_SPAR_02_snd_F";
-        primaryWeaponItems[] = {"bipod_01_F_snd", "RH_SFM952V_tan"};
+        primaryWeaponItems[] = {"optic_Holosight", "RH_HBLM_des", "RH_SFM952V_tan"};
         vestMagazines[] = {{"150Rnd_556x45_Drum_Mag_F", 2}};
         backpackMagazines[] = {
             {"150Rnd_556x45_Drum_Mag_F", 2},

--- a/hull3/assign/gear/HK416_CTRG_TRP.h
+++ b/hull3/assign/gear/HK416_CTRG_TRP.h
@@ -132,7 +132,7 @@ class HK416_CTRG_TRP {
 
     class AR : Rifleman {
         primaryWeapon = "arifle_SPAR_02_khk_F";
-        primaryWeaponItems[] = {"bipod_01_F_blk", "RH_SFM952V"};
+        primaryWeaponItems[] = {"optic_Holosight_khk_F", "RH_HBLM_tg", "RH_SFM952V"};
         vestMagazines[] = {{"150Rnd_556x45_Drum_Mag_F", 2}};
         backpackMagazines[] = {
             {"150Rnd_556x45_Drum_Mag_F", 2},

--- a/hull3/assign/gear/HK416_KSK.h
+++ b/hull3/assign/gear/HK416_KSK.h
@@ -128,7 +128,7 @@ class HK416_KSK {
 
     class AR : Rifleman {
         primaryWeapon = "arifle_SPAR_02_blk_F";
-        primaryWeaponItems[] = {"RH_SFM952V"};
+        primaryWeaponItems[] = {"RH_compM2", "RH_SFM952V", "RH_HBLM"};
         vestMagazines[] = {{"150Rnd_556x45_Drum_Mag_F", 3}};
         backpackMagazines[] = {
             {"HandGrenade", 1},

--- a/hull3/assign/gear/M4A1_USMC.h
+++ b/hull3/assign/gear/M4A1_USMC.h
@@ -130,7 +130,7 @@ class M4A1_USMC {
 
     class AR : Rifleman {
         primaryWeapon = "arifle_SPAR_02_blk_F";
-        primaryWeaponItems[] = {"RH_SFM952V", "RH_HBLM"};
+        primaryWeaponItems[] = {"RH_compM2", "RH_SFM952V", "RH_HBLM"};
         vestMagazines[] = {{"150Rnd_556x45_Drum_Mag_F", 4}};
         backpackMagazines[] = {
             {"HandGrenade", 1},


### PR DESCRIPTION
As per continued requests from AR users, CQC sights for M27s.