### PR TITLE
Reverting to old setFog method, looks more reliable in MP

### DIFF
--- a/hull3/mission_functions.sqf
+++ b/hull3/mission_functions.sqf
@@ -123,7 +123,7 @@ hull3_mission_fnc_setWeather = {
 hull3_mission_fnc_setEnviroment = {
     setDate ([] call hull3_mission_fnc_getDateTime);
     [0, [] call hull3_mission_fnc_getWeather] call hull3_mission_fnc_setWeather;
-    ([] call hull3_mission_fnc_getFog) call BIS_fnc_setFog;
+    0 setFog ([] call hull3_mission_fnc_getFog);
     DEBUG("hull3.mission.weather",FMT_3("Environment was set. Date to '%1', fog to '%2' and weather to '%3'.",[] call hull3_mission_fnc_getDateTime,[] call hull3_mission_fnc_getFog,[] call hull3_mission_fnc_getWeather));
 };
 


### PR DESCRIPTION
Did a quick local dedi test, using our existing method setting fog to Heavy in description.ext: 

bis_fnc_setFog:
`fogParams` returns: [0,0,0]
`fogForecast` returns: 0

0 setfog:
`fogParams` returns: [0.4,0,0]
`fogForecast` returns: 0.4

It looks like BI's fnc doesn't set the forecast value correctly so fog vanishes after 20 minutes or so (probably can be seen using `nextWeatherChange`).