### PR TITLE
Weather clean up

### DIFF
--- a/hull3/config.cpp
+++ b/hull3/config.cpp
@@ -91,10 +91,6 @@ class Cfg3DEN {
     class EventHandlers {
         class Hull3 {
             OnMissionLoad       = "call (uiNamespace getVariable 'hull3_eden_fnc_intelSettings');";
-            OnMissionNew        = "call (uiNamespace getVariable 'hull3_eden_fnc_intelSettings');";
-            OnMissionPreview    = "call (uiNamespace getVariable 'hull3_eden_fnc_intelSettings');";
-            OnMissionPreviewEnd = "call (uiNamespace getVariable 'hull3_eden_fnc_intelSettings');";
-            OnTerrainNew        = "call (uiNamespace getVariable 'hull3_eden_fnc_intelSettings');";
             OnMissionSave       = "call (uiNamespace getVariable 'hull3_eden_fnc_intelSettings');";
         };
     };

--- a/hull3/eden_functions.sqf
+++ b/hull3/eden_functions.sqf
@@ -3,12 +3,6 @@ hull3_eden_fnc_intelSettings = {
         ["Intel", "IntelDate", [2035,6,12]],
         ["Intel", "IntelTimeOfChanges", 28800],
         ["Intel", "IntelWavesIsForced", true],
-        ["Intel", "IntelWavesStart", 0],
-        ["Intel", "IntelWavesForecast", 0],
-        ["Intel", "IntelWindIsForced", true],
-        ["Intel", "IntelWindStart", 0],
-        ["Intel", "IntelWindForecast", 0],
-        ["Intel", "IntelWindGustStart", 0],
-        ["Intel", "IntelWindGustForecast", 0]
+        ["Intel", "IntelWindIsForced", true]
     ];
 };

--- a/hull3/mission_functions.sqf
+++ b/hull3/mission_functions.sqf
@@ -109,7 +109,7 @@ hull3_mission_fnc_getFog = {
 
 hull3_mission_fnc_getWeather = {
     if (isNil {hull3_mission_weather}) then {
-        hull3_mission_weather = [0, 0, 0, 0, 0, 0, 0, 0];
+        hull3_mission_weather = [0, 0, 0, 0, 0, 0, 0];
         TRACE("hull3.mission.weather",FMT_1("Mission param 'hull3_mission_weather' was not set, using default '%1'.",hull3_mission_weather));
     };
     if (hull3_mission_weather #0 == -1 && {isServer}) then {
@@ -118,7 +118,7 @@ hull3_mission_fnc_getWeather = {
         TRACE("hull3.mission.weather",FMT_1("Random weather was selected. Generated random weather '%1' for server.",hull3_mission_weather));
     } else {
         if (!isDedicated && !isServer) then {
-            hull3_mission_weather = [0, 0, 0, 0, 0, 0, 0, 0];
+            hull3_mission_weather = [0, 0, 0, 0, 0, 0, 0];
             TRACE("hull3.mission.weather",FMT_1("Random weather was selected. Using default weather '%1' for client.",hull3_mission_weather));
         };
     };

--- a/hull3/mission_params.h
+++ b/hull3/mission_params.h
@@ -24,17 +24,17 @@ class MissionParams {
         {0.4, 0, 0} // Heavy
     };
 
-    // Overcast, Rain, Rainbow, Lightnings, Wind Strength, Wind Gusts, Waves, Humidity
+    // Overcast, Rain, Rainbow, Lightnings, Wind Strength, Wind Gusts, Waves
     weather[] = {
-        {-1}, // Random
-        {0,     0,      0,      0,      0,      0,      0,      0}, // Clear (Calm)
-        {0.01,  0,      0,      0,      0.25,   0.5,    0.25,   0.2}, // Clear (Light Winds)
-        {0.01,  0,      0,      0,      0.50,   0.75,   0.75,   0.2}, // Clear (Stong Winds)
-        {0.48,  0,      0,      0,      0,      0,      0.1,    0.2}, // Overcast (Calm)
-        {0.48,  0,      0,      0,      0.25,   0.5,    0.25,   0.2}, // Overcast (Light Winds)
-        {0.48,  0,      0,      0,      0.50,   0.75,   0.75,   0.2}, // Overcast (Strong Winds)
-        {1,     1,      0,      0,      0.25,   0.5,    0.75,   0.9}, // Rain (Light Winds)
-        {1,     1,      0,      0,      0.50,   0.75,   0.75,   0.9}, // Rain (Strong Winds)
-        {1,     1,      0,      1,      0.75,     1,      1,      1}, // Storm
+        {-1},                                   // Random
+        {0, 0, 0, 0, 0, 0,  0},                 // Clear (Calm)
+        {0.01, 0, 0, 0, 0.25, 0.5, 0.25},       // Clear (Light Winds)
+        {0.01, 0, 0, 0, 0.50, 0.75, 0.75},      // Clear (Stong Winds)
+        {0.48, 0, 0, 0, 0,  0, 0.1},            // Overcast (Calm)
+        {0.48, 0, 0, 0, 0.25, 0.5, 0.25},       // Overcast (Light Winds)
+        {0.48, 0, 0, 0, 0.50, 0.75, 0.75},      // Overcast (Strong Winds)
+        {1, 1, 0, 0, 0.25, 0.5, 0.75},          // Rain (Light Winds)
+        {1, 1, 0, 0, 0.50, 0.75, 0.75},         // Rain (Strong Winds)
+        {1, 1, 0, 1, 0.75, 1, 1}                // Storm
     };
 };

--- a/hull3/mission_params.h
+++ b/hull3/mission_params.h
@@ -26,19 +26,19 @@ class MissionParams {
 
     // Overcast, Rain, Rainbow, Lightnings, Wind Strength, Wind Gusts, Waves
     weather[] = {
-        {-1},                                                   // Random
+        {-1},                                                      // Random
         
-        {0,    0,    0,    0,    0,    0,    0},                // Clear (Calm)
-        {0,    0,    0,    0,    0.25,    0.25,    0.25},       // Clear (Light Winds)
-        {0,    0,    0,    0,    0.50,    0.50,    0.50},       // Clear (Stong Winds)
+        {0,       0,    0,    0,       0,       0,       0},       // Clear (Calm)
+        {0,       0,    0,    0,       0.25,    0.25,    0.25},    // Clear (Light Winds)
+        {0,       0,    0,    0,       0.50,    0.50,    0.50},    // Clear (Stong Winds)
         
-        {0.48,    0,    0,    0,    0,    0,    0},             // Overcast (Calm)
-        {0.48,    0,    0,    0,    0.25,    0.25,    0.25},    // Overcast (Light Winds)
-        {0.48,    0,    0,    0,    0.50,    0.50,    0.50},    // Overcast (Strong Winds)
+        {0.48,    0,    0,    0,       0,       0,       0},       // Overcast (Calm)
+        {0.48,    0,    0,    0,       0.25,    0.25,    0.25},    // Overcast (Light Winds)
+        {0.48,    0,    0,    0,       0.50,    0.50,    0.50},    // Overcast (Strong Winds)
         
-        {1,    1,    0,    0.25,    0.25,    0.25,    0.25},    // Rain (Light Winds)
-        {1,    1,    0,    0.50,    0.50,    0.50,    0.50},    // Rain (Strong Winds)
+        {1,       1,    0,    0.25,    0.25,    0.25,    0.25},    // Rain (Light Winds)
+        {1,       1,    0,    0.50,    0.50,    0.50,    0.50},    // Rain (Strong Winds)
         
-        {1,    1,    0,    1,    0.75,    1,    1}              // Storm
+        {1,       1,    0,    1,       0.75,    1,       1}        // Storm
     };
 };

--- a/hull3/mission_params.h
+++ b/hull3/mission_params.h
@@ -26,19 +26,19 @@ class MissionParams {
 
     // Overcast, Rain, Rainbow, Lightnings, Wind Strength, Wind Gusts, Waves
     weather[] = {
-        {-1},                                   // Random
+        {-1},                                                   // Random
         
-        {0, 0, 0, 0, 0, 0, 0},                  // Clear (Calm)
-        {0, 0, 0, 0, 0.25, 0.25, 0.25},         // Clear (Light Winds)
-        {0, 0, 0, 0, 0.50, 0.50, 0.50},         // Clear (Stong Winds)
+        {0,    0,    0,    0,    0,    0,    0},                // Clear (Calm)
+        {0,    0,    0,    0,    0.25,    0.25,    0.25},       // Clear (Light Winds)
+        {0,    0,    0,    0,    0.50,    0.50,    0.50},       // Clear (Stong Winds)
         
-        {0.48, 0, 0, 0, 0, 0, 0},               // Overcast (Calm)
-        {0.48, 0, 0, 0, 0.25, 0.25, 0.25},      // Overcast (Light Winds)
-        {0.48, 0, 0, 0, 0.50, 0.50, 0.50},      // Overcast (Strong Winds)
+        {0.48,    0,    0,    0,    0,    0,    0},             // Overcast (Calm)
+        {0.48,    0,    0,    0,    0.25,    0.25,    0.25},    // Overcast (Light Winds)
+        {0.48,    0,    0,    0,    0.50,    0.50,    0.50},    // Overcast (Strong Winds)
         
-        {1, 1, 0, 0.25, 0.25, 0.25, 0.25},      // Rain (Light Winds)
-        {1, 1, 0, 0.50, 0.50, 0.50, 0.50},      // Rain (Strong Winds)
+        {1,    1,    0,    0.25,    0.25,    0.25,    0.25},    // Rain (Light Winds)
+        {1,    1,    0,    0.50,    0.50,    0.50,    0.50},    // Rain (Strong Winds)
         
-        {1, 1, 0, 1, 0.75, 1, 1}                // Storm
+        {1,    1,    0,    1,    0.75,    1,    1}              // Storm
     };
 };

--- a/hull3/mission_params.h
+++ b/hull3/mission_params.h
@@ -27,14 +27,18 @@ class MissionParams {
     // Overcast, Rain, Rainbow, Lightnings, Wind Strength, Wind Gusts, Waves
     weather[] = {
         {-1},                                   // Random
-        {0, 0, 0, 0, 0, 0,  0},                 // Clear (Calm)
-        {0.01, 0, 0, 0, 0.25, 0.5, 0.25},       // Clear (Light Winds)
-        {0.01, 0, 0, 0, 0.50, 0.75, 0.75},      // Clear (Stong Winds)
-        {0.48, 0, 0, 0, 0,  0, 0.1},            // Overcast (Calm)
-        {0.48, 0, 0, 0, 0.25, 0.5, 0.25},       // Overcast (Light Winds)
-        {0.48, 0, 0, 0, 0.50, 0.75, 0.75},      // Overcast (Strong Winds)
-        {1, 1, 0, 0, 0.25, 0.5, 0.75},          // Rain (Light Winds)
-        {1, 1, 0, 0, 0.50, 0.75, 0.75},         // Rain (Strong Winds)
+        
+        {0, 0, 0, 0, 0, 0, 0},                  // Clear (Calm)
+        {0, 0, 0, 0, 0.25, 0.25, 0.25},         // Clear (Light Winds)
+        {0, 0, 0, 0, 0.50, 0.50, 0.50},         // Clear (Stong Winds)
+        
+        {0.48, 0, 0, 0, 0, 0, 0},               // Overcast (Calm)
+        {0.48, 0, 0, 0, 0.25, 0.25, 0.25},      // Overcast (Light Winds)
+        {0.48, 0, 0, 0, 0.50, 0.50, 0.50},      // Overcast (Strong Winds)
+        
+        {1, 1, 0, 0.25, 0.25, 0.25, 0.25},      // Rain (Light Winds)
+        {1, 1, 0, 0.50, 0.50, 0.50, 0.50},      // Rain (Strong Winds)
+        
         {1, 1, 0, 1, 0.75, 1, 1}                // Storm
     };
 };


### PR DESCRIPTION
Adjusted the Eden functions to hopefully remove the case where terrains with ground close to sea level get caught in under terrain waves.

Removed references to Humidity (killed during the Alpha of A3), shrunk the `hull3_mission_weather` array to seven elements as we never call the 8th element.

Reformatted, reviewed and adjusted the default weather conditions, there were some odd numbers used throughout so I've standardised them to what I think is a sensible level. Hopefully they're a bit more readable now too.