### PR TITLE
Adding ACE_wirecutters to all loadouts

### DIFF
--- a/hull3/assign/gear/ACR_BLK_PMC.h
+++ b/hull3/assign/gear/ACR_BLK_PMC.h
@@ -27,7 +27,10 @@ class ACR_BLK_PMC {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/ACR_TAN_PMC.h
+++ b/hull3/assign/gear/ACR_TAN_PMC.h
@@ -27,7 +27,10 @@ class ACR_TAN_PMC {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AEK_RU.h
+++ b/hull3/assign/gear/AEK_RU.h
@@ -27,7 +27,10 @@ class AEK_RU {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK12_RU.h
+++ b/hull3/assign/gear/AK12_RU.h
@@ -27,7 +27,10 @@ class AK12_RU {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK12_SYND.h
+++ b/hull3/assign/gear/AK12_SYND.h
@@ -23,7 +23,10 @@ class AK12_SYND {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK47_NK.h
+++ b/hull3/assign/gear/AK47_NK.h
@@ -27,7 +27,10 @@ class AK47_NK {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK74M_RU.h
+++ b/hull3/assign/gear/AK74M_RU.h
@@ -27,7 +27,10 @@ class AK74M_RU {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK74_DPR.h
+++ b/hull3/assign/gear/AK74_DPR.h
@@ -27,7 +27,10 @@ class AK74_DPR {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK74_NK.h
+++ b/hull3/assign/gear/AK74_NK.h
@@ -27,7 +27,10 @@ class AK74_NK {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK74_RU.h
+++ b/hull3/assign/gear/AK74_RU.h
@@ -27,7 +27,10 @@ class AK74_RU {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK74_SLA.h
+++ b/hull3/assign/gear/AK74_SLA.h
@@ -26,7 +26,10 @@ class AK74_SLA {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK74_TKA.h
+++ b/hull3/assign/gear/AK74_TKA.h
@@ -26,7 +26,10 @@ class AK74_TKA {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AK74_UKR.h
+++ b/hull3/assign/gear/AK74_UKR.h
@@ -27,7 +27,10 @@ class AK74_UKR {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKM_CHKDZ.h
+++ b/hull3/assign/gear/AKM_CHKDZ.h
@@ -26,7 +26,10 @@ class AKM_CHKDZ {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKM_IRN.h
+++ b/hull3/assign/gear/AKM_IRN.h
@@ -27,7 +27,10 @@ class ARM_IRN {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKM_NAPA.h
+++ b/hull3/assign/gear/AKM_NAPA.h
@@ -26,7 +26,10 @@ class AKM_NAPA {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKM_NPA.h
+++ b/hull3/assign/gear/AKM_NPA.h
@@ -27,7 +27,10 @@ class AKM_NPA {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKM_SLA.h
+++ b/hull3/assign/gear/AKM_SLA.h
@@ -26,7 +26,10 @@ class AKM_SLA {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKM_SYND.h
+++ b/hull3/assign/gear/AKM_SYND.h
@@ -23,7 +23,10 @@ class AKM_SYND {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKM_TKI.h
+++ b/hull3/assign/gear/AKM_TKI.h
@@ -26,7 +26,10 @@ class AKM_TKI {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKM_TKL.h
+++ b/hull3/assign/gear/AKM_TKL.h
@@ -26,7 +26,10 @@ class AKM_TKL {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKS74_CDF.h
+++ b/hull3/assign/gear/AKS74_CDF.h
@@ -27,7 +27,10 @@ class AKS74_CDF {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AKS74_RU.h
+++ b/hull3/assign/gear/AKS74_RU.h
@@ -27,7 +27,10 @@ class AKS74_RU {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AUGA3_AUS.h
+++ b/hull3/assign/gear/AUGA3_AUS.h
@@ -27,7 +27,10 @@ class AUGA3_AUS {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AUGA3_IRE.h
+++ b/hull3/assign/gear/AUGA3_IRE.h
@@ -27,7 +27,10 @@ class AUGA3_IRE {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/AUGA3_NZ.h
+++ b/hull3/assign/gear/AUGA3_NZ.h
@@ -27,7 +27,10 @@ class AUGA3_NZ {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/CAR15_GEND.h
+++ b/hull3/assign/gear/CAR15_GEND.h
@@ -27,7 +27,10 @@ class CAR15_GEND {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/CAR95_CN.h
+++ b/hull3/assign/gear/CAR95_CN.h
@@ -27,7 +27,10 @@ class CAR95_CN {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/CAR95_CSAT.h
+++ b/hull3/assign/gear/CAR95_CSAT.h
@@ -27,7 +27,10 @@ class CAR95_CSAT {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/Default.h
+++ b/hull3/assign/gear/Default.h
@@ -15,7 +15,10 @@ class Default {
         basicAssignItems[] = {};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/FAL_TKA.h
+++ b/hull3/assign/gear/FAL_TKA.h
@@ -27,7 +27,10 @@ class FAL_TKA {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/FOW_BAF_42_G.h
+++ b/hull3/assign/gear/FOW_BAF_42_G.h
@@ -18,7 +18,10 @@ class FOW_BAF_42_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/FOW_BAF_44_G.h
+++ b/hull3/assign/gear/FOW_BAF_44_G.h
@@ -18,7 +18,10 @@ class FOW_BAF_44_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/FOW_BAF_PAC_G.h
+++ b/hull3/assign/gear/FOW_BAF_PAC_G.h
@@ -18,7 +18,10 @@ class FOW_BAF_PAC_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/FOW_GER_G.h
+++ b/hull3/assign/gear/FOW_GER_G.h
@@ -18,7 +18,10 @@ class FOW_GER_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/FOW_GER_PARA_G.h
+++ b/hull3/assign/gear/FOW_GER_PARA_G.h
@@ -18,7 +18,10 @@ class FOW_GER_PARA_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/FOW_IJA_G.h
+++ b/hull3/assign/gear/FOW_IJA_G.h
@@ -18,7 +18,10 @@ class FOW_IJA_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/FOW_USA_G.h
+++ b/hull3/assign/gear/FOW_USA_G.h
@@ -18,7 +18,10 @@ class FOW_USA_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/FOW_USMC_G.h
+++ b/hull3/assign/gear/FOW_USMC_G.h
@@ -18,7 +18,10 @@ class FOW_USMC_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/G36_GER.h
+++ b/hull3/assign/gear/G36_GER.h
@@ -27,7 +27,10 @@ class G36_GER {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/G36_KSK.h
+++ b/hull3/assign/gear/G36_KSK.h
@@ -27,7 +27,10 @@ class G36_KSK {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/G3A3_IRN.h
+++ b/hull3/assign/gear/G3A3_IRN.h
@@ -27,7 +27,10 @@ class G3A3_IRN {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/G3KA4_NOR.h
+++ b/hull3/assign/gear/G3KA4_NOR.h
@@ -27,7 +27,10 @@ class G3KA4_NOR {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/HK416_CTRG_BLK.h
+++ b/hull3/assign/gear/HK416_CTRG_BLK.h
@@ -27,7 +27,10 @@ class HK416_CTRG_BLK {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/HK416_CTRG_DE.h
+++ b/hull3/assign/gear/HK416_CTRG_DE.h
@@ -27,7 +27,10 @@ class HK416_CTRG_DE {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/HK416_CTRG_TRP.h
+++ b/hull3/assign/gear/HK416_CTRG_TRP.h
@@ -27,7 +27,10 @@ class HK416_CTRG_TRP {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/HK416_KSK.h
+++ b/hull3/assign/gear/HK416_KSK.h
@@ -27,7 +27,10 @@ class HK416_KSK {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/IF44_USSR_G.h
+++ b/hull3/assign/gear/IF44_USSR_G.h
@@ -18,7 +18,10 @@ class IF44_USSR_G {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {};

--- a/hull3/assign/gear/Katiba_CSAT.h
+++ b/hull3/assign/gear/Katiba_CSAT.h
@@ -27,7 +27,10 @@ class Katiba_CSAT {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/Katiba_IRN.h
+++ b/hull3/assign/gear/Katiba_IRN.h
@@ -27,7 +27,10 @@ class Katiba_IRN {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/L85_BAF.h
+++ b/hull3/assign/gear/L85_BAF.h
@@ -26,7 +26,10 @@ class L85_BAF {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/L85_BAF_RIS.h
+++ b/hull3/assign/gear/L85_BAF_RIS.h
@@ -26,7 +26,10 @@ class L85_BAF_RIS {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M14_US.h
+++ b/hull3/assign/gear/M14_US.h
@@ -27,7 +27,10 @@ class M14_US {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M16A2_US.h
+++ b/hull3/assign/gear/M16A2_US.h
@@ -27,7 +27,10 @@ class M16A2_US {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M16A3_CDF.h
+++ b/hull3/assign/gear/M16A3_CDF.h
@@ -27,7 +27,10 @@ class M16A3_CDF {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M16A3_RACS.h
+++ b/hull3/assign/gear/M16A3_RACS.h
@@ -27,7 +27,10 @@ class M16A3_RACS {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M16A4_CAN.h
+++ b/hull3/assign/gear/M16A4_CAN.h
@@ -27,7 +27,10 @@ class M16A4_CAN {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M16A4_ROK.h
+++ b/hull3/assign/gear/M16A4_ROK.h
@@ -27,7 +27,10 @@ class M16A4_ROK {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M16A4_USMC.h
+++ b/hull3/assign/gear/M16A4_USMC.h
@@ -27,7 +27,10 @@ class M16A4_USMC {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M4A1_US.h
+++ b/hull3/assign/gear/M4A1_US.h
@@ -27,7 +27,10 @@ class M4A1_US {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M4A1_USMC.h
+++ b/hull3/assign/gear/M4A1_USMC.h
@@ -27,7 +27,10 @@ class M4A1_USMC {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/M4_US.h
+++ b/hull3/assign/gear/M4_US.h
@@ -27,7 +27,10 @@ class M4_US {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/MIX_LVM.h
+++ b/hull3/assign/gear/MIX_LVM.h
@@ -27,7 +27,10 @@ class MIX_LVM {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/MP5_GEND.h
+++ b/hull3/assign/gear/MP5_GEND.h
@@ -27,7 +27,10 @@ class MP5_GEND {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/MX_NATO.h
+++ b/hull3/assign/gear/MX_NATO.h
@@ -27,7 +27,10 @@ class MX_NATO {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/MX_NATO_BLK.h
+++ b/hull3/assign/gear/MX_NATO_BLK.h
@@ -27,7 +27,10 @@ class MX_NATO_BLK {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/MX_NATO_TRP.h
+++ b/hull3/assign/gear/MX_NATO_TRP.h
@@ -27,7 +27,10 @@ class MX_NATO_TRP {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/Mk20_AAF_WD.h
+++ b/hull3/assign/gear/Mk20_AAF_WD.h
@@ -26,7 +26,10 @@ class Mk20_AAF_WD {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/RK62_FIN.h
+++ b/hull3/assign/gear/RK62_FIN.h
@@ -27,7 +27,10 @@ class RK62_FIN {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/SCAR_H_US.h
+++ b/hull3/assign/gear/SCAR_H_US.h
@@ -27,7 +27,10 @@ class SCAR_H_US {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/SCAR_L_PMC.h
+++ b/hull3/assign/gear/SCAR_L_PMC.h
@@ -27,7 +27,10 @@ class SCAR_L_PMC {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/SCAR_L_US.h
+++ b/hull3/assign/gear/SCAR_L_US.h
@@ -27,7 +27,10 @@ class SCAR_L_US {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/SIG550_CDF.h
+++ b/hull3/assign/gear/SIG550_CDF.h
@@ -27,7 +27,10 @@ class SIG550_CDF {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/TRG_FIA.h
+++ b/hull3/assign/gear/TRG_FIA.h
@@ -26,7 +26,10 @@ class TRG_FIA {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};

--- a/hull3/assign/gear/VZ58_FIN.h
+++ b/hull3/assign/gear/VZ58_FIN.h
@@ -27,7 +27,10 @@ class VZ58_FIN {
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
         binocular = "";
-        uniformItems[] = {{"ACE_Flashlight_KSF1", 1}};
+        uniformItems[] = {
+            {"ACE_Flashlight_KSF1", 1},
+            {"ACE_wirecutter", 1}
+        };
         vestItems[] = {};
         backpackItems[] = {};
         uniformRadios[] = {"ACRE_PRC343"};


### PR DESCRIPTION
ark_inhouse reduces their mass to 1 so shouldn't tip the scales over on any of the existing loadouts!