### PR TITLE
Moving CUP 5.56 weapon to their own mag classes

### DIFF
--- a/hull3/assign/gear/L85_BAF.h
+++ b/hull3/assign/gear/L85_BAF.h
@@ -14,14 +14,14 @@ class L85_BAF {
             {"SmokeShell", 1}
         };
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 2},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 4},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
@@ -51,18 +51,18 @@ class L85_BAF {
         handgunWeapon = "hlc_pistol_P226US";
         primaryWeaponItems[] = {};
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
             {"1Rnd_HE_Grenade_shell", 4},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2},
             {"hlc_15Rnd_9x19_B_P226", 3}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_L85", 4},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
             {"UGL_FlareWhite_F", 2}
@@ -84,7 +84,7 @@ class L85_BAF {
             {"SmokeShell", 1}
         };
         uniformRadios[] = {"ACRE_PRC343", "ACRE_PRC152"};
-        vestMagazines[] = {{"30Rnd_556x45_Stanag", 4}};
+        vestMagazines[] = {{"CUP_30Rnd_556x45_Stanag_L85", 4}};
         backpackMagazines[] = {};
         assignItems[] = {"ItemGPS", "ACE_NVG_Wide"};
     };
@@ -105,13 +105,13 @@ class L85_BAF {
 
     class Medic : Rifleman {
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2},
             {"SmokeShell", 4}
         };
         backpackMagazines[] = {
             {"SmokeShellBlue", 4},
-            {"30Rnd_556x45_Stanag", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 2}
         };
         assignItems[] = {"ItemGPS"};
         binocular = "Binocular";
@@ -151,14 +151,14 @@ class L85_BAF {
     class RAT : Rifleman {
         secondaryWeapon = "CUP_launch_M72A6";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 4},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
     };
 
@@ -333,8 +333,8 @@ class L85_BAF {
 
     class ENG : Rifleman {
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"Toolkit", 1},
@@ -396,8 +396,8 @@ class L85_BAF {
             {"CUP_launch_M72A6", 5}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 15},
-            {"30Rnd_556x45_Stanag", 15},
+            {"CUP_30Rnd_556x45_Stanag_L85", 15},
+            {"CUP_30Rnd_556x45_Stanag_L85", 15},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 10},
             {"1Rnd_Smoke_Grenade_shell", 5},
             {"UGL_FlareWhite_F", 5},
@@ -425,8 +425,8 @@ class L85_BAF {
             {"CUP_launch_M72A6", 10}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag", 20},
+            {"CUP_30Rnd_556x45_Stanag_L85", 40},
+            {"CUP_30Rnd_556x45_Stanag_L85", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
@@ -453,8 +453,8 @@ class L85_BAF {
     class Armored : Truck {
         weapons[] = {{"CUP_launch_M72A6", 10}};
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag", 20},
+            {"CUP_30Rnd_556x45_Stanag_L85", 40},
+            {"CUP_30Rnd_556x45_Stanag_L85", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},

--- a/hull3/assign/gear/L85_BAF_RIS.h
+++ b/hull3/assign/gear/L85_BAF_RIS.h
@@ -14,14 +14,14 @@ class L85_BAF_RIS {
             {"SmokeShell", 1}
         };
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 2},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 4},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
@@ -51,18 +51,18 @@ class L85_BAF_RIS {
         primaryWeaponItems[] = {"optic_Holosight_blk_F", "RH_SFM952V"};
         handgunWeapon = "CUP_hgun_Glock17_blk";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
             {"1Rnd_HE_Grenade_shell", 4},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2},
             {"CUP_17Rnd_9x19_glock17", 3}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_L85", 4},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
             {"UGL_FlareWhite_F", 2}
@@ -84,7 +84,7 @@ class L85_BAF_RIS {
             {"SmokeShell", 1}
         };
         uniformRadios[] = {"ACRE_PRC343", "ACRE_PRC152"};
-        vestMagazines[] = {{"30Rnd_556x45_Stanag", 4}};
+        vestMagazines[] = {{"CUP_30Rnd_556x45_Stanag_L85", 4}};
         backpackMagazines[] = {};
         assignItems[] = {"ItemGPS", "ACE_NVG_Wide"};
     };
@@ -105,13 +105,13 @@ class L85_BAF_RIS {
 
     class Medic : Rifleman {
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2},
             {"SmokeShell", 4}
         };
         backpackMagazines[] = {
             {"SmokeShellBlue", 4},
-            {"30Rnd_556x45_Stanag", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 2}
         };
         assignItems[] = {"ItemGPS"};
         binocular = "Binocular";
@@ -152,14 +152,14 @@ class L85_BAF_RIS {
     class RAT : Rifleman {
         secondaryWeapon = "CUP_launch_NLAW";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 4},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
     };
 
@@ -334,8 +334,8 @@ class L85_BAF_RIS {
 
     class ENG : Rifleman {
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_L85", 6},
+            {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"Toolkit", 1},
@@ -397,8 +397,8 @@ class L85_BAF_RIS {
             {"CUP_launch_NLAW", 5}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 15},
-            {"30Rnd_556x45_Stanag", 15},
+            {"CUP_30Rnd_556x45_Stanag_L85", 15},
+            {"CUP_30Rnd_556x45_Stanag_L85", 15},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 10},
             {"1Rnd_Smoke_Grenade_shell", 5},
             {"UGL_FlareWhite_F", 5},
@@ -426,8 +426,8 @@ class L85_BAF_RIS {
             {"CUP_launch_NLAW", 10}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag", 20},
+            {"CUP_30Rnd_556x45_Stanag_L85", 40},
+            {"CUP_30Rnd_556x45_Stanag_L85", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
@@ -454,8 +454,8 @@ class L85_BAF_RIS {
     class Armored : Truck {
         weapons[] = {{"CUP_launch_NLAW", 10}};
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag", 20},
+            {"CUP_30Rnd_556x45_Stanag_L85", 40},
+            {"CUP_30Rnd_556x45_Stanag_L85", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},

--- a/hull3/assign/gear/M16A2_US.h
+++ b/hull3/assign/gear/M16A2_US.h
@@ -15,14 +15,14 @@ class M16A2_US {
             {"SmokeShell", 1}
         };
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag", 4},
+            {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
@@ -51,18 +51,18 @@ class M16A2_US {
         primaryWeapon = "CUP_arifle_M16A2_GL";
         handgunWeapon = "CUP_hgun_M9";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag", 6},
             {"1Rnd_HE_Grenade_shell", 4},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2},
             {"CUP_15Rnd_9x19_M9", 3}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag", 4},
+            {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
             {"UGL_FlareWhite_F", 2}
@@ -84,7 +84,7 @@ class M16A2_US {
             {"SmokeShell", 1}
         };
         uniformRadios[] = {"ACRE_PRC343", "ACRE_PRC152"};
-        vestMagazines[] = {{"30Rnd_556x45_Stanag", 4}};
+        vestMagazines[] = {{"CUP_30Rnd_556x45_Stanag", 4}};
         backpackMagazines[] = {};
         assignItems[] = {"ItemGPS", "ACE_NVG_Wide"};
     };
@@ -105,13 +105,13 @@ class M16A2_US {
 
     class Medic : Rifleman {
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2},
             {"SmokeShell", 4}
         };
         backpackMagazines[] = {
             {"SmokeShellBlue", 4},
-            {"30Rnd_556x45_Stanag", 2}
+            {"CUP_30Rnd_556x45_Stanag", 2}
         };
         assignItems[] = {"ItemGPS"};
         binocular = "Binocular";
@@ -151,14 +151,14 @@ class M16A2_US {
         primaryWeaponItems[] = {};
         secondaryWeapon = "CUP_launch_M72A6";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag", 4},
+            {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
     };
 
@@ -332,8 +332,8 @@ class M16A2_US {
 
     class ENG : Rifleman {
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"Toolkit", 1},
@@ -395,8 +395,8 @@ class M16A2_US {
             {"CUP_launch_M72A6", 5}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 15},
-            {"30Rnd_556x45_Stanag", 15},
+            {"CUP_30Rnd_556x45_Stanag", 15},
+            {"CUP_30Rnd_556x45_Stanag", 15},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 10},
             {"1Rnd_Smoke_Grenade_shell", 5},
             {"UGL_FlareWhite_F", 5},
@@ -424,8 +424,8 @@ class M16A2_US {
             {"CUP_launch_M72A6", 10}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag", 20},
+            {"CUP_30Rnd_556x45_Stanag", 40},
+            {"CUP_30Rnd_556x45_Stanag", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"hlc_100Rnd_762x51_M_M60E4", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
@@ -452,8 +452,8 @@ class M16A2_US {
     class Armored : Truck {
         weapons[] = {{"CUP_launch_M72A6", 10}};
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag", 20},
+            {"CUP_30Rnd_556x45_Stanag", 40},
+            {"CUP_30Rnd_556x45_Stanag", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"hlc_100Rnd_762x51_M_M60E4", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},

--- a/hull3/assign/gear/SCAR_L_PMC.h
+++ b/hull3/assign/gear/SCAR_L_PMC.h
@@ -15,14 +15,14 @@ class SCAR_L_PMC {
             {"SmokeShell", 1}
         };
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 4},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black_Tracer_Red", 2}
         };
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
@@ -52,18 +52,18 @@ class SCAR_L_PMC {
         primaryWeaponItems[] = {"optic_Holosight_blk_F", "RH_SFM952V"};
         handgunWeapon = "CUP_hgun_M9";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 6},
             {"1Rnd_HE_Grenade_shell", 4},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black_Tracer_Red", 2},
             {"CUP_15Rnd_9x19_M9", 3}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 4},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black_Tracer_Red", 2},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
             {"UGL_FlareWhite_F", 2}
@@ -109,13 +109,13 @@ class SCAR_L_PMC {
         primaryWeapon = "CUP_arifle_Mk16_STD_FG_black";
         primaryWeaponItems[] = {"RH_compM2l", "RH_SFM952V"};
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black_Tracer_Red", 2},
             {"SmokeShell", 4}
         };
         backpackMagazines[] = {
             {"SmokeShellBlue", 4},
-            {"30Rnd_556x45_Stanag", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 2}
         };
         assignItems[] = {"ItemGPS"};
         binocular = "Binocular";
@@ -156,14 +156,14 @@ class SCAR_L_PMC {
         primaryWeaponItems[] = {"RH_compM2l", "RH_SFM952V"};
         secondaryWeapon = "CUP_launch_M136";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 4},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black_Tracer_Red", 2}
         };
     };
 
@@ -345,8 +345,8 @@ class SCAR_L_PMC {
         primaryWeapon = "CUP_arifle_Mk16_CQC_FG_black";
         primaryWeaponItems[] = {"RH_compM2l", "RH_SFM952V"};
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"Toolkit", 1},
@@ -409,8 +409,8 @@ class SCAR_L_PMC {
             {"CUP_arifle_Mk16_CQC_FG_black", 2}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 15},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 15},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 15},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 15},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 10},
             {"1Rnd_Smoke_Grenade_shell", 5},
             {"UGL_FlareWhite_F", 5},
@@ -439,8 +439,8 @@ class SCAR_L_PMC {
             {"CUP_arifle_Mk16_CQC_FG_black", 2}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 20},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 40},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
@@ -467,8 +467,8 @@ class SCAR_L_PMC {
     class Armored : Truck {
         weapons[] = {{"CUP_launch_M136", 10}};
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 20},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 40},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_black", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},

--- a/hull3/assign/gear/SCAR_L_US.h
+++ b/hull3/assign/gear/SCAR_L_US.h
@@ -15,14 +15,14 @@ class SCAR_L_US {
             {"SmokeShell", 1}
         };
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 4},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2}
         };
         basicAssignItems[] = {"ItemMap", "ItemCompass", "ItemWatch"};
         assignItems[] = {};
@@ -52,18 +52,18 @@ class SCAR_L_US {
         primaryWeaponItems[] = {"optic_Holosight_blk_F", "RH_SFM952V_tan"};
         handgunWeapon = "CUP_hgun_M9";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 6},
             {"1Rnd_HE_Grenade_shell", 4},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2},
             {"CUP_15Rnd_9x19_M9", 3}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 4},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2},
             {"1Rnd_Smoke_Grenade_shell", 2},
             {"1Rnd_SmokeRed_Grenade_shell", 2},
             {"UGL_FlareWhite_F", 2}
@@ -109,13 +109,13 @@ class SCAR_L_US {
         primaryWeapon = "CUP_arifle_Mk16_CQC_FG";
         primaryWeaponItems[] = {"RH_compM2l", "RH_SFM952V_tan"};
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2},
             {"SmokeShell", 4}
         };
         backpackMagazines[] = {
             {"SmokeShellBlue", 4},
-            {"30Rnd_556x45_Stanag", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 2}
         };
         assignItems[] = {"ItemGPS"};
         binocular = "Binocular";
@@ -156,14 +156,14 @@ class SCAR_L_US {
         primaryWeaponItems[] = {"RH_compM2l", "RH_SFM952V_tan"};
         secondaryWeapon = "CUP_launch_M136";
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"30Rnd_556x45_Stanag", 4},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 4},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2}
         };
     };
 
@@ -345,8 +345,8 @@ class SCAR_L_US {
         primaryWeapon = "CUP_arifle_Mk16_CQC_FG";
         primaryWeaponItems[] = {"RH_compM2l", "RH_SFM952V_tan"};
         vestMagazines[] = {
-            {"30Rnd_556x45_Stanag", 6},
-            {"30Rnd_556x45_Stanag_Tracer_Red", 2}
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 6},
+            {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2}
         };
         backpackMagazines[] = {
             {"Toolkit", 1},
@@ -409,8 +409,8 @@ class SCAR_L_US {
             {"CUP_arifle_Mk16_CQC_FG", 2}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 15},
-            {"30Rnd_556x45_Stanag", 15},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 15},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 15},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 10},
             {"1Rnd_Smoke_Grenade_shell", 5},
             {"UGL_FlareWhite_F", 5},
@@ -439,8 +439,8 @@ class SCAR_L_US {
             {"CUP_arifle_Mk16_CQC_FG", 2}
         };
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag", 20},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 40},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
@@ -467,8 +467,8 @@ class SCAR_L_US {
     class Armored : Truck {
         weapons[] = {{"CUP_launch_M136", 10}};
         magazines[] = {
-            {"30Rnd_556x45_Stanag", 40},
-            {"30Rnd_556x45_Stanag", 20},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 40},
+            {"CUP_30Rnd_556x45_Stanag_Mk16", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
             {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},


### PR DESCRIPTION
Will stop invisible and clipping mags in these templates.

There are few templates using mixed HLC/CUP loadouts that probably need a case by case review, I've left those untouched for now.