### PR TITLE
Removing legacy ACE variable

### DIFF
--- a/hull3/gear_functions.sqf
+++ b/hull3/gear_functions.sqf
@@ -80,7 +80,6 @@ hull3_gear_fnc_assignUnitInit = {
     _unit setVariable ["hull3_faction", _faction, true];
     _unit setVariable ["hull3_gear_class", _class, true];
     _unit setVariable ["hull3_gear_template", _template, true];
-    _unit setVariable ["ace_medical_medicClass", 2, true]; // Allow everyone to use ACE epi-pen
     removeAllAssignedItems _unit;
     removeAllPrimaryWeaponItems _unit;
     removeAllHandgunItems _unit;


### PR DESCRIPTION
This is making riflemen have medic icons in the DUI squad hud. I think this is a legacy variable as I built a version without this line and we're still able to give epi/morphine etc.