### PR TITLE
Fireteam marker improvements

### DIFF
--- a/hull3/config.cpp
+++ b/hull3/config.cpp
@@ -96,5 +96,16 @@ class Cfg3DEN {
     };
 };
 
+class CfgMarkers {
+    class Flag;
+    class Hull3_UnitMarker : Flag {
+        name = "Unit Icon";
+        icon = "\A3\ui_f\data\map\vehicleicons\iconMan_ca.paa";
+        color[] = {1, 0, 0, 1};
+        shadow = true;
+        scope = 1;
+    };
+};
+
 // Hull3
 #include "hull3.h"

--- a/hull3/marker_functions.sqf
+++ b/hull3/marker_functions.sqf
@@ -198,7 +198,7 @@ hull3_marker_fnc_addFireTeamMarker = {
         _markerName,
         getPosATL _unit,
         "ICON",
-        "mil_triangle",
+        "Hull3_UnitMarker",
         ["Marker", "FireTeamMemberMarker", "color"] call hull3_config_fnc_getText,
         "",
         ["Marker", "FireTeamMemberMarker", "size"] call hull3_config_fnc_getArray


### PR DESCRIPTION
Retiring the old triangle for a more modern unit icon from A3.