### PR TITLE
Adds support for Hull markers to have an alpha value

### DIFF
--- a/hull3/hull3.h
+++ b/hull3/hull3.h
@@ -239,8 +239,9 @@ class Hull3 {
         };
 
         class FireTeamMemberMarker {
+            alpha = 0.5;
             color = "ColorYellow";
-            size[] = {0.6, 0.6};
+            size[] = {0.5, 0.5};
         };
 
         class DefaultCustomMarker {

--- a/hull3/marker_functions.sqf
+++ b/hull3/marker_functions.sqf
@@ -201,7 +201,8 @@ hull3_marker_fnc_addFireTeamMarker = {
         "Hull3_UnitMarker",
         ["Marker", "FireTeamMemberMarker", "color"] call hull3_config_fnc_getText,
         "",
-        ["Marker", "FireTeamMemberMarker", "size"] call hull3_config_fnc_getArray
+        ["Marker", "FireTeamMemberMarker", "size"] call hull3_config_fnc_getArray,
+        ["Marker", "FireTeamMemberMarker", "alpha"] call hull3_config_fnc_getNumber
     ] call hull3_marker_fnc_createMarker;
     _unit setVariable ["hull3_marker_fireTeam", _markerName];
     PUSH(hull3_marker_fireTeam,_unit);
@@ -264,7 +265,7 @@ hull3_marker_fnc_deleteCustomMarker = {
 };
 
 hull3_marker_fnc_createMarker = {
-    params ["_name", "_position", "_shape", "_type", "_color", "_text", "_size"];
+    params ["_name", "_position", "_shape", "_type", "_color", "_text", "_size", "_alpha"];
 
     createMarkerLocal [_name, _position];
     _name setMarkerShapeLocal _shape;
@@ -273,6 +274,11 @@ hull3_marker_fnc_createMarker = {
     _name setMarkerTextLocal _text;
     if (!isNil "_size") then {
         _name setMarkerSizeLocal _size;
+    };
+    if (!isNil "_alpha") then {
+        _name setMarkerAlphaLocal _alpha;
+    } else {
+        _name setMarkerAlphaLocal 1;
     };
 
     _name;


### PR DESCRIPTION
Added support for setting alpha values on markers created by Hull. Written to keep supporting old calls and fall back to a value of 1 is the arg isn't passed so doesn't break any existing configurations.

In the future I'll add the ability to set alpha to `hull3_marker_fnc_addCustomMarker` too.

By default I've dropped the FireTeamMemberMarker to 50% alpha so that it doesn't over power the Squad markers. I'll update this a bit more based on feedback in sessions.