### PR TITLE
Fixing custom markers

### DIFF
--- a/hull3/marker_functions.sqf
+++ b/hull3/marker_functions.sqf
@@ -126,7 +126,7 @@ hull3_marker_fnc_updateCustomMarkers = {
     [
         {
             {
-                [_x] call hull3_marker_fnc_updateCustomMarker;
+                _x call hull3_marker_fnc_updateCustomMarker;
             } foreach hull3_marker_custom;
         },
         1


### PR DESCRIPTION
Already passes an array, this means it ends up nesting it and breaking.