### PR TITLE
Stop AI units moving around when in building/over water

### DIFF
--- a/hull3/unit_functions.sqf
+++ b/hull3/unit_functions.sqf
@@ -16,6 +16,7 @@ hull3_unit_fnc_init = {
         _uniformEntry = [_initEntries, "uniform"] call hull3_config_fnc_getEntry;
         [_unit, _factionEntry, _gearEntry, _uniformEntry] call hull3_gear_fnc_assign;
         [_unit] call hull3_unit_fnc_addEHs;
+        doStop _unit; // Order doStop to stop AI wondering around over water (boats etc)
     };
     _markerEntry = [_initEntries, "marker"] call hull3_config_fnc_getEntry;
     if (count _markerEntry > 0) then {


### PR DESCRIPTION
Quick test in local MP seems to work, is under a `local` check so shouldn't run on players.

You can still order AI to move it just stops them initially moving on their own and causing issues, e.g. if you leave AI in a player controlled team and the FTL moves, the AI won't follow anymore unless ordered.