### PR TITLE
Garbage cleaner rewrite

### DIFF
--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -96,7 +96,7 @@ hull3_gc_fnc_monitorDead = {
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
             for "_i" from 0 to (hull3_gc_deadUnits - hull3_gc_currentCorpseLimit) do {
-                [(hull3_gc_deadUnits select #0)] call ark_gc_fnc_cleanDead;
+                [(hull3_gc_deadUnits #0)] call ark_gc_fnc_cleanDead;
                 _removedCount = _removedCount + 1;
             };
         };
@@ -110,7 +110,7 @@ hull3_gc_fnc_monitorDead = {
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
             for "_i" from 0 to (hull3_gc_deadVehicles - hull3_gc_currentWreckLimit) do {
-                [(hull3_gc_deadVehicles select #0)] call ark_gc_fnc_cleanDead;
+                [(hull3_gc_deadVehicles #0)] call ark_gc_fnc_cleanDead;
                 _removedCount = _removedCount + 1;
             };
         };

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -92,10 +92,11 @@ hull3_gc_fnc_monitorDead = {
     if (hull3_gc_canRemoveCorpses) then {
         DEBUG("hull3.gc","Starting next corpse GC check.");
         private _removedCount = 0;
-        private _limitReached = (count hull3_gc_deadUnits) > hull3_gc_currentCorpseLimit;
+        private _deadAmount = count hull3_gc_deadUnits;
+        private _limitReached = _deadAmount > hull3_gc_currentCorpseLimit;
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
-            for "_i" from 0 to (hull3_gc_deadUnits - hull3_gc_currentCorpseLimit) do {
+            for "_i" from 0 to (_deadAmount - hull3_gc_currentCorpseLimit) do {
                 [(hull3_gc_deadUnits #0)] call ark_gc_fnc_cleanDead;
                 _removedCount = _removedCount + 1;
             };
@@ -106,10 +107,11 @@ hull3_gc_fnc_monitorDead = {
     if (hull3_gc_canRemoveWrecks) then {
         DEBUG("hull3.gc","Starting next wreck GC check.");
         private _removedCount = 0;
-        private _limitReached = (count hull3_gc_deadVehicles) > hull3_gc_currentWreckLimit;
+        private _wreckAmount = count hull3_gc_deadVehicles;
+        private _limitReached = _wreckAmount > hull3_gc_currentWreckLimit;
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
-            for "_i" from 0 to (hull3_gc_deadVehicles - hull3_gc_currentWreckLimit) do {
+            for "_i" from 0 to (_wreckAmount - hull3_gc_currentWreckLimit) do {
                 [(hull3_gc_deadVehicles #0)] call ark_gc_fnc_cleanDead;
                 _removedCount = _removedCount + 1;
             };

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -101,7 +101,6 @@ hull3_gc_fnc_monitorDead = {
                 hull3_gc_deadUnits deleteAt 0;
                 _removedCount = _removedCount + 1;
             };
-        {if (count units _x == 0) then {deleteGroup _x}} forEach allGroups
         };
         DEBUG("hull3.gc",FMT_1("Removed '%1' units.",_removedCount));
     };

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -97,8 +97,7 @@ hull3_gc_fnc_monitorDead = {
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_1("Limit '%1' reached, removing units.",_limit));
             for "_i" from 0 to (_deadAmount - hull3_gc_currentCorpseLimit) do {
-                (hull3_gc_deadUnits #0) call hull3_gc_fnc_cleanDead;
-                hull3_gc_deadUnits deleteAt 0;
+                (hull3_gc_deadUnits deleteAt 0) call ark_gc_fnc_cleanDead;
                 _removedCount = _removedCount + 1;
             };
         };
@@ -113,8 +112,7 @@ hull3_gc_fnc_monitorDead = {
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_1("Limit '%1' reached, removing wrecks.",_limit));
             for "_i" from 0 to (_wreckAmount - hull3_gc_currentWreckLimit) do {
-                (hull3_gc_deadVehicles #0) call hull3_gc_fnc_cleanDead;
-                hull3_gc_deadVehicles deleteAt 0;
+                (hull3_gc_deadVehicles deleteAt 0) call ark_gc_fnc_cleanDead;
                 _removedCount = _removedCount + 1;
             };
         };

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -97,7 +97,9 @@ hull3_gc_fnc_monitorDead = {
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
             for "_i" from 0 to (_deadAmount - hull3_gc_currentCorpseLimit) do {
-                [(hull3_gc_deadUnits #0)] call ark_gc_fnc_cleanDead;
+                private _unit = hull3_gc_deadUnits #0;
+                _unit call ark_gc_fnc_cleanDead;
+                hull3_gc_deadUnits deleteAt 0;
                 _removedCount = _removedCount + 1;
             };
         };
@@ -112,7 +114,9 @@ hull3_gc_fnc_monitorDead = {
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
             for "_i" from 0 to (_wreckAmount - hull3_gc_currentWreckLimit) do {
-                [(hull3_gc_deadVehicles #0)] call ark_gc_fnc_cleanDead;
+                private _veh = hull3_gc_deadVehicles #0;
+                _veh call ark_gc_fnc_cleanDead;
+                hull3_gc_deadVehicles deleteAt 0;
                 _removedCount = _removedCount + 1;
             };
         };

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -121,7 +121,7 @@ hull3_gc_fnc_monitorDead = {
 
     // Engine should take care of this but it can't hurt to manually run every loop to do extra clean up
     {
-        if (count units _x == 0) then {
+        if (count units _x isEqualTo 0) then {
             if (local _x) then {
                 deleteGroup _x;
             } else {

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -97,8 +97,7 @@ hull3_gc_fnc_monitorDead = {
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
             for "_i" from 0 to (_deadAmount - hull3_gc_currentCorpseLimit) do {
-                private _unit = hull3_gc_deadUnits #0;
-                _unit call ark_gc_fnc_cleanDead;
+                (hull3_gc_deadUnits #0) call hull3_gc_fnc_cleanDead;
                 hull3_gc_deadUnits deleteAt 0;
                 _removedCount = _removedCount + 1;
             };
@@ -115,8 +114,7 @@ hull3_gc_fnc_monitorDead = {
         if (_limitReached) then {
             TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
             for "_i" from 0 to (_wreckAmount - hull3_gc_currentWreckLimit) do {
-                private _veh = hull3_gc_deadVehicles #0;
-                _veh call ark_gc_fnc_cleanDead;
+                (hull3_gc_deadVehicles #0) call hull3_gc_fnc_cleanDead;
                 hull3_gc_deadVehicles deleteAt 0;
                 _removedCount = _removedCount + 1;
             };
@@ -124,18 +122,19 @@ hull3_gc_fnc_monitorDead = {
         DEBUG("hull3.gc",FMT_1("Removed '%1' wrecks.",_removedCount));
     };
 
+    // Engine should take care of this but it can't hurt to manually run every loop to do extra clean up
     {
         if (count units _x == 0) then {
             if (local _x) then {
                 deleteGroup _x;
             } else {
-                _group remoteExec ["deleteGroup", groupOwner _group];
+                _x remoteExec ["deleteGroup", groupOwner _x];
             };
         };
     } forEach allGroups;
 };
 
-ark_gc_fnc_cleanDead = {
+hull3_gc_fnc_cleanDead = {
     params ["_obj"];
 
     if (_obj isKindOf "CAManBase") then {

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -95,7 +95,7 @@ hull3_gc_fnc_monitorDead = {
         private _deadAmount = count hull3_gc_deadUnits;
         private _limitReached = _deadAmount > hull3_gc_currentCorpseLimit;
         if (_limitReached) then {
-            TRACE("hull3.gc",FMT_1("Limit '%1' reached, removing units.",_limit));
+            TRACE("hull3.gc",FMT_2("Limit '%1' of '%2' reached, removing corpses.",_deadAmount,hull3_gc_currentCorpseLimit));
             for "_i" from 0 to (_deadAmount - hull3_gc_currentCorpseLimit) do {
                 (hull3_gc_deadUnits deleteAt 0) call ark_gc_fnc_cleanDead;
                 _removedCount = _removedCount + 1;
@@ -110,7 +110,7 @@ hull3_gc_fnc_monitorDead = {
         private _wreckAmount = count hull3_gc_deadVehicles;
         private _limitReached = _wreckAmount > hull3_gc_currentWreckLimit;
         if (_limitReached) then {
-            TRACE("hull3.gc",FMT_1("Limit '%1' reached, removing wrecks.",_limit));
+            TRACE("hull3.gc",FMT_2("Limit '%1' of '%2' reached, removing wrecks.",_wreckAmount,hull3_gc_currentWreckLimit));
             for "_i" from 0 to (_wreckAmount - hull3_gc_currentWreckLimit) do {
                 (hull3_gc_deadVehicles deleteAt 0) call ark_gc_fnc_cleanDead;
                 _removedCount = _removedCount + 1;

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -41,7 +41,7 @@ hull3_gc_fnc_start = {
             call hull3_gc_fnc_monitor;
             hull3_gc_deadUnits = [];
             hull3_gc_deadVehicles = [];
-            addMissionEventHandler ["EntityKilled",{call hull3_gc_fnc_sortDead}];
+            hull3_gc_eh_sortDead = addMissionEventHandler ["EntityKilled",{call hull3_gc_fnc_sortDead}];
         },
         [],
         5
@@ -52,6 +52,9 @@ hull3_gc_fnc_stop = {
     hull3_gc_canRemoveCorpses = false;
     hull3_gc_canRemoveWrecks = false;
     hull3_gc_isEnabled = false;
+    removeMissionEventHandler ["EntityKilled", hull3_gc_eh_sortDead];
+    hull3_gc_deadUnits = nil;
+    hull3_gc_deadVehicles = nil;
 };
 
 hull3_gc_fnc_monitor = {

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -102,6 +102,7 @@ hull3_gc_fnc_monitorDead = {
                 hull3_gc_deadUnits deleteAt 0;
                 _removedCount = _removedCount + 1;
             };
+        {if (count units _x == 0) then {deleteGroup _x}} forEach allGroups
         };
         DEBUG("hull3.gc",FMT_1("Removed '%1' units.",_removedCount));
     };
@@ -122,6 +123,16 @@ hull3_gc_fnc_monitorDead = {
         };
         DEBUG("hull3.gc",FMT_1("Removed '%1' wrecks.",_removedCount));
     };
+
+    {
+        if (count units _x == 0) then {
+            if (local _x) then {
+                deleteGroup _x;
+            } else {
+                _group remoteExec ["deleteGroup", groupOwner _group];
+            };
+        };
+    } forEach allGroups;
 };
 
 ark_gc_fnc_cleanDead = {

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -11,59 +11,59 @@ hull3_gc_fnc_preInit = {
     hull3_gc_isEnabled = ["GarbageCollector", "isEnabled"] call hull3_config_fnc_getBool;
     hull3_gc_canRemoveCorpses = ["GarbageCollector", "canRemoveCorpses"] call hull3_config_fnc_getBool;
     hull3_gc_canRemoveWrecks = ["GarbageCollector", "canRemoveWrecks"] call hull3_config_fnc_getBool;
-    hull3_gc_canRemoveGroups = ["GarbageCollector", "canRemoveGroups"] call hull3_config_fnc_getBool;
 
     hull3_gc_panicCps = ["GarbageCollector", "panicCps"] call hull3_config_fnc_getNumber;
 
     hull3_gc_corpseLimit = ["GarbageCollector", "corpseLimit"] call hull3_config_fnc_getNumber;
     hull3_gc_panicCorpseLimit = ["GarbageCollector", "panicCorpseLimit"] call hull3_config_fnc_getNumber;
-    hull3_gc_corpseMaxTime = ["GarbageCollector", "corpseMaxTime"] call hull3_config_fnc_getNumber;
-    hull3_gc_panicCorpseMaxTime = ["GarbageCollector", "panicCorpseMaxTime"] call hull3_config_fnc_getNumber;
 
     hull3_gc_wreckLimit = ["GarbageCollector", "wreckLimit"] call hull3_config_fnc_getNumber;
     hull3_gc_panicWreckLimit = ["GarbageCollector", "panicWreckLimit"] call hull3_config_fnc_getNumber;
-    hull3_gc_wreckMaxTime = ["GarbageCollector", "wreckMaxTime"] call hull3_config_fnc_getNumber;
-    hull3_gc_panicWreckMaxTime = ["GarbageCollector", "panicWreckMaxTime"] call hull3_config_fnc_getNumber;
 
-    hull3_gc_groupMaxTime = ["GarbageCollector", "groupMaxTime"] call hull3_config_fnc_getNumber;
     hull3_gc_checkDelay = ["GarbageCollector", "checkDelay"] call hull3_config_fnc_getNumber;
 
     hull3_gc_currentCorpseLimit = hull3_gc_corpseLimit;
-    hull3_gc_currentCorpseMaxTime = hull3_gc_corpseMaxTime;
     hull3_gc_currentWreckLimit = hull3_gc_wreckLimit;
-    hull3_gc_currentWreckMaxTime = hull3_gc_wreckMaxTime;
 };
 
 hull3_gc_fnc_start = {
-    sleep 1;
-    {
-        _x setVariable ["hull3_gc_canRemove", false];
-    } foreach playableUnits;
-    {
-        _x setVariable ["hull3_gc_canRemove", false];
-    } foreach allDead;
-    hull3_gc_canRemoveCorpses = true;
-    hull3_gc_canRemoveWrecks = true;
-    hull3_gc_canRemoveGroups = true;
-    hull3_gc_isEnabled = true;
-    [] spawn hull3_gc_fnc_monitor;
+    [
+        {
+            {
+                _x setVariable ["hull3_gc_doNotRemove", true, false];
+            } foreach playableUnits;
+            {
+                _x setVariable ["hull3_gc_doNotRemove", true, false];
+            } foreach allDead;
+            hull3_gc_canRemoveCorpses = true;
+            hull3_gc_canRemoveWrecks = true;
+            hull3_gc_isEnabled = true;
+            call hull3_gc_fnc_monitor;
+            hull3_gc_deadUnits = [];
+            hull3_gc_deadVehicles = [];
+            addMissionEventHandler ["EntityKilled",{call hull3_gc_fnc_sortDead}];
+        },
+        [],
+        5
+    ] call CBA_fnc_waitAndExecute;
 };
 
 hull3_gc_fnc_stop = {
     hull3_gc_canRemoveCorpses = false;
     hull3_gc_canRemoveWrecks = false;
-    hull3_gc_canRemoveGroups = false;
     hull3_gc_isEnabled = false;
 };
 
 hull3_gc_fnc_monitor = {
-    while {hull3_gc_isEnabled} do {
-        [] call hull3_gc_fnc_adjustConfig;
-        [] call hull3_gc_fnc_monitorCorpses;
-        [] call hull3_gc_fnc_monitorWrecks;
-        [] call hull3_gc_fnc_monitorGroups;
-        sleep hull3_gc_checkDelay;
-    };
+    [
+        {
+            if {hull3_gc_isEnabled} then {
+                call hull3_gc_fnc_adjustConfig;
+                call hull3_gc_fnc_monitorDead;
+            };
+        },
+        hull3_gc_checkDelay
+    ] call CBA_fnc_addPerFrameHandler;
 };
 
 hull3_gc_fnc_adjustConfig = {
@@ -71,122 +71,66 @@ hull3_gc_fnc_adjustConfig = {
     private _currentCps = [] call ark_asm_fnc_getCurrentCps;
     if (_currentCps <= hull3_gc_panicCps) then {
         hull3_gc_currentCorpseLimit = hull3_gc_panicCorpseLimit;
-        hull3_gc_currentCorpseMaxTime = hull3_gc_panicCorpseMaxTime;
         hull3_gc_currentWreckLimit = hull3_gc_panicWreckLimit;
-        hull3_gc_currentWreckMaxTime = hull3_gc_panicWreckMaxTime;
     } else {
         hull3_gc_currentCorpseLimit = hull3_gc_corpseLimit;
-        hull3_gc_currentCorpseMaxTime = hull3_gc_corpseMaxTime;
         hull3_gc_currentWreckLimit = hull3_gc_wreckLimit;
-        hull3_gc_currentWreckMaxTime = hull3_gc_wreckMaxTime;
     };
 };
 
-hull3_gc_fnc_monitorCorpses = {
+hull3_gc_fnc_sortDead = {
+    params ["_killed"];
+    if (isPlayer _killed || { _killed getVariable ["hull3_gc_doNotRemove", false] } ) exitWith {};
+
+    if (_killed isKindOf "CAManBase") then {
+         hull3_gc_deadUnits pushBack _killed;
+    } else {
+        hull3_gc_deadVehicles pushBack _killed;
+    };
+};
+
+hull3_gc_fnc_monitorDead = {
     if (hull3_gc_canRemoveCorpses) then {
         DEBUG("hull3.gc","Starting next corpse GC check.");
-        [hull3_gc_currentCorpseLimit, hull3_gc_currentCorpseMaxTime, {_x isKindOf "Man"}] call hull3_gc_fnc_tryRemovingUnits;
-    };
-};
-
-hull3_gc_fnc_monitorWrecks = {
-    if (hull3_gc_canRemoveWrecks) then {
-        DEBUG("hull3.gc","Starting next wreck GC check.");
-        [hull3_gc_currentWreckLimit, hull3_gc_currentWreckMaxTime, {!(_x isKindOf "Man")}] call hull3_gc_fnc_tryRemovingUnits;
-    };
-};
-
-hull3_gc_fnc_tryRemovingUnits = {
-    params ["_limit", "_maxTime", "_isKindOfFunc"];
-
-    private _units = allDead select { GC_CAN_REMOVE(_x) && _isKindOfFunc };
-    DEBUG("hull3.gc",FMT_1("'%1' dead units.",count _units));
-    private _limitReached = count _units > _limit;
-    private _removedCount = 0;
-    {
-        if (isNil {_x getVariable "hull3_gc_firstCheck"}) then {
-            _x setVariable ["hull3_gc_firstCheck", time, false];
-            TRACE("hull3.gc",FMT_2("Setting 'firstCheck' of unit '%1' to '%2'.",_x,time));
-        };
-        if (_limitReached && { [_x, _maxTime] call hull3_gc_fnc_canRemoveUnit }) then {
-            TRACE("hull3.gc",FMT_3("Limit '%1' and max time '%2' reached, removing unit '%3'.",_limit,_maxTime,_x));
-            if (isNull objectParent _x) then {
-                deleteVehicle _x;
-            } else {
-                objectParent _x deleteVehicleCrew _x;
+        private _removedCount = 0;
+        private _totalDead = count hull3_gc_deadUnits;
+        private _limitReached =_totalDead > hull3_gc_currentCorpseLimit;
+        if (_limitReached) then {
+            TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
+            for "_i" from 0 to (hull3_gc_deadUnits - hull3_gc_currentCorpseLimit) do {
+                [(hull3_gc_deadUnits select #0)] call ark_gc_fnc_cleanDead;
+                _removedCount = _removedCount + 1;
             };
-            _removedCount = _removedCount + 1;
-        };
-    } foreach _units;
-    DEBUG("hull3.gc",FMT_2("Removed '%1' units for reaching max time '%2'.",_removedCount,_maxTime));
-
-    private _existingUnits = _units select { !isNil {_x} && {!isNull _x} };
-    if (count _existingUnits > _limit) then {
-        DEBUG("hull3.gc",FMT_1("Limit '%1' reached, starting to remove '%2' units.",_limit,count _existingUnits - _limit));
-        _removedCount = 0;
-        for "_i" from 0 to (count _existingUnits - _limit - 1) do {
-            private _selectedExistingUnit = _existingUnits select _i;
-            TRACE("hull3.gc",FMT_1("Removing unit '%1'.",_selectedExistingUnit));
-            if (isNull objectParent _selectedExistingUnit) then {
-                deleteVehicle _selectedExistingUnit;
-            } else {
-                objectParent _selectedExistingUnit deleteVehicleCrew _selectedExistingUnit;
-            };
-            deleteVehicle (_existingUnits select _i);
-            _removedCount = _removedCount + 1;
         };
         DEBUG("hull3.gc",FMT_1("Removed '%1' units.",_removedCount));
     };
-};
 
-hull3_gc_fnc_canRemoveUnit = {
-    FUN_ARGS_2(_unit,_maxTime);
-
-    private ["_canRemove", "_timeSinceFirstCheck"];
-    _canRemove = GC_CAN_REMOVE(_unit);
-    _timePassed = time - (_unit getVariable ["hull3_gc_firstCheck", time]);
-
-    _canRemove && {_timePassed >= _maxTime};
-};
-
-hull3_gc_fnc_monitorGroups = {
-    if (hull3_gc_canRemoveGroups) then {
-        private ["_removeCount", "_remoteGroups"];
-        DEBUG("hull3.gc","Starting next group GC check.");
-        _remoteGroups = [];
-        _removeCount = 0;
-        {
-            if (count units _x == 0) then {
-                call {
-                    if !(_x getVariable ["hull3_gc_isMarked", false]) exitWith {
-                        _x setVariable ["hull3_gc_isMarked", true];
-                    };
-
-                    if (!local _x) then {
-                        PUSH(_remoteGroups,_x);
-                    };
-                    INC(_removeCount);
-                    if (!isNull _x) then {
-                        deleteGroup _x;
-                    };
-                };
-            } else {
-                _x setVariable ["hull3_gc_isMarked", false];
+    if (hull3_gc_canRemoveWrecks) then {
+        DEBUG("hull3.gc","Starting next wreck GC check.");
+        private _removedCount = 0;
+        private _totalWrecks = count hull3_gc_deadVehicles;
+        private _limitReached =_totalWrecks > hull3_gc_currentWreckLimit;
+        if (_limitReached) then {
+            TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
+            for "_i" from 0 to (hull3_gc_deadVehicles - hull3_gc_currentCorpseLimit) do {
+                [(hull3_gc_deadVehicles select #0)] call ark_gc_fnc_cleanDead;
+                _removedCount = _removedCount + 1;
             };
-        } foreach allGroups;
-        DEBUG("hull3.gc",FMT_2("Removing total '%1' groups of which '%2' are remote.",_removeCount,count _remoteGroups));
-        [_remoteGroups] call hull3_gc_fnc_removeRemoteGroups;
+        };
+        DEBUG("hull3.gc",FMT_1("Removed '%1' wrecks.",_removedCount));
     };
 };
 
-hull3_gc_fnc_removeRemoteGroups = {
-    FUN_ARGS_1(_groups);
+ark_gc_fnc_cleanDead = {
+    params ["_obj"];
 
-    [-1, {
-        {
-            if (!isNull _x && {local _x}) then {
-                deleteGroup _x;
-            };
-        } foreach _this;
-    }, _groups] call CBA_fnc_globalExecute;
+    if (_obj isKindOf "CAManBase") then {
+        if (isNull objectParent _obj) then {
+            deleteVehicle _obj;
+        } else {
+            objectParent _obj deleteVehicleCrew _obj;
+        };
+    } else {
+        deleteVehicle _obj;
+    };
 };

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -56,10 +56,10 @@ hull3_gc_fnc_stop = {
 hull3_gc_fnc_monitor = {
     [
         {
-            if (hull3_gc_isEnabled) then {
-                call hull3_gc_fnc_adjustConfig;
-                call hull3_gc_fnc_monitorDead;
-            };
+            params ["", "_id"];
+            if !(hull3_gc_isEnabled) exitWith {_id call CBA_fnc_removePerFrameHandler};
+            call hull3_gc_fnc_adjustConfig;
+            call hull3_gc_fnc_monitorDead;
         },
         hull3_gc_checkDelay
     ] call CBA_fnc_addPerFrameHandler;

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -95,7 +95,7 @@ hull3_gc_fnc_monitorDead = {
         private _deadAmount = count hull3_gc_deadUnits;
         private _limitReached = _deadAmount > hull3_gc_currentCorpseLimit;
         if (_limitReached) then {
-            TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
+            TRACE("hull3.gc",FMT_1("Limit '%1' reached, removing units.",_limit));
             for "_i" from 0 to (_deadAmount - hull3_gc_currentCorpseLimit) do {
                 (hull3_gc_deadUnits #0) call hull3_gc_fnc_cleanDead;
                 hull3_gc_deadUnits deleteAt 0;
@@ -112,7 +112,7 @@ hull3_gc_fnc_monitorDead = {
         private _wreckAmount = count hull3_gc_deadVehicles;
         private _limitReached = _wreckAmount > hull3_gc_currentWreckLimit;
         if (_limitReached) then {
-            TRACE("hull3.gc",FMT_2("Limit '%1' reached, removing unit '%2'.",_limit,_x));
+            TRACE("hull3.gc",FMT_1("Limit '%1' reached, removing wrecks.",_limit));
             for "_i" from 0 to (_wreckAmount - hull3_gc_currentWreckLimit) do {
                 (hull3_gc_deadVehicles #0) call hull3_gc_fnc_cleanDead;
                 hull3_gc_deadVehicles deleteAt 0;

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -56,7 +56,7 @@ hull3_gc_fnc_stop = {
 hull3_gc_fnc_monitor = {
     [
         {
-            if {hull3_gc_isEnabled} then {
+            if (hull3_gc_isEnabled) then {
                 call hull3_gc_fnc_adjustConfig;
                 call hull3_gc_fnc_monitorDead;
             };

--- a/hull3/hull3.h
+++ b/hull3/hull3.h
@@ -351,21 +351,15 @@ class Hull3 {
         isEnabled = 1;
         canRemoveCorpses = 1;
         canRemoveWrecks = 1;
-        canRemoveGroups = 1;
 
         panicCps = 20;
 
         corpseLimit = 40;
         panicCorpseLimit = 10;
-        corpseMaxTime = 600;
-        panicCorpseMaxTime = 20;
 
         wreckLimit = 10;
         panicWreckLimit = 3;
-        wreckMaxTime = 600;
-        panicWreckMaxTime = 60;
 
-        groupMaxTime = 90;
         checkDelay = 30;
     };
 };

--- a/hull3/hull3_postinit.sqf
+++ b/hull3/hull3_postinit.sqf
@@ -15,11 +15,11 @@ if (hull3_isEnabled) then {
         if (isServer) then {
             [] call hull3_mission_fnc_serverInit;
             [] call hull3_unit_fnc_foreachNonPlayerUnits;
-            [] spawn hull3_gc_fnc_start;
+            [] call hull3_gc_fnc_start;
         };
     } else {
         [] call hull3_mission_fnc_serverInit;
         [] call hull3_unit_fnc_foreachNonPlayerUnits;
-        [] spawn hull3_gc_fnc_start;
+        [] call hull3_gc_fnc_start;
     };
 };


### PR DESCRIPTION
I've simplified a lot of this to hopefully make it leaner and faster. I've tried to keep to the same principals as the existing GC to not cause any major issues and shouldn't effect any older missions (I hope...)

- No more element specific time checks (they never worked in the existing code)
- No more group clean up settings (Not sure why you'd ever need to keep empty groups + engine now cleans them up, see Admiral PR)
- Removed spawn and while loops, using one CBA PFH and an EH to track the dead
- Deletes oldest units first so should take car of 90% of the issues where bodies vanish as you're shooting them