### PR TITLE
GC improvement

### DIFF
--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -80,12 +80,11 @@ hull3_gc_fnc_adjustConfig = {
 hull3_gc_fnc_sortDead = {
     params ["_killed"];
     if (isPlayer _killed || { _killed getVariable ["hull3_gc_doNotRemove", false] } ) exitWith {};
+    if (_killed isKindOf "Logic" || { _killed isKindOf "Static" } || {  _killed isKindOf "Thing" } ) exitWith {};
 
     if (_killed isKindOf "CAManBase") then {
          hull3_gc_deadUnits pushBack _killed;
-    };
-
-    if (_killed isKindOf "Car" || { _killed isKindOf "Tank" } || { _killed isKindOf "Air" } || { _killed isKindOf "Ship" }) then {
+    } else {
         hull3_gc_deadVehicles pushBack _killed;
     };
 };

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -83,7 +83,9 @@ hull3_gc_fnc_sortDead = {
 
     if (_killed isKindOf "CAManBase") then {
          hull3_gc_deadUnits pushBack _killed;
-    } else {
+    };
+
+    if (_killed isKindOf "Car" || { _killed isKindOf "Tank" } || { _killed isKindOf "Air" } || { _killed isKindOf "Ship" }) then {
         hull3_gc_deadVehicles pushBack _killed;
     };
 };


### PR DESCRIPTION
Following on from the rewrite after some _heavy_ testing last night I noticed that the `entityKilled` EH returns all entities (that should have been obvious). So while I was filtering `CAManBase` in to one array, the wrecks array was full of `Static` classes (buildings/fences destroyed).

Did some code testing to figure out the fastest method to do this (don't want overhead here as it runs any time anything dies). The exitWith is the fastest method 0.0034ms overhead to filter out the crap. Seems acceptable!