### PR TITLE
Change m60s to CUP

### DIFF
--- a/hull3/assign/gear/CAR15_GEND.h
+++ b/hull3/assign/gear/CAR15_GEND.h
@@ -162,14 +162,14 @@ class CAR15_GEND {
     };
 
     class MMGG : Rifleman {
-        primaryWeapon = "hlc_lmg_m60";
+        primaryWeapon = "CUP_lmg_M60";
         primaryWeaponItems[] = {};
-        vestMagazines[] = {{"hlc_100Rnd_762x51_M_M60E4", 1}};
+        vestMagazines[] = {{"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 1}};
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 2},
-            {"hlc_100Rnd_762x51_T_M60E4", 2}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 2},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 2}
         };
     };
 
@@ -177,7 +177,7 @@ class CAR15_GEND {
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
         binocular = "ACE_VectorDay";
         assignItems[] = {"ItemGPS"};
@@ -427,7 +427,7 @@ class CAR15_GEND {
             {"CUP_30Rnd_556x45_Stanag", 40},
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 20},
             {"CUP_100Rnd_TE1_Red_Tracer_556x45_BetaCMag_ar15", 20},
-            {"hlc_100Rnd_762x51_M_M60E4", 10},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"CUP_1Rnd_Smoke_M203", 10},
             {"CUP_FlareWhite_M203", 10},
             {"SatchelCharge_Remote_Mag", 5},
@@ -455,7 +455,7 @@ class CAR15_GEND {
             {"CUP_30Rnd_556x45_Stanag", 40},
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 20},
             {"CUP_100Rnd_TE1_Red_Tracer_556x45_BetaCMag_ar15", 20},
-            {"hlc_100Rnd_762x51_M_M60E4", 10},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"CUP_1Rnd_Smoke_M203", 10},
             {"CUP_FlareWhite_M203", 10},
             {"MRAWS_HEAT_F", 5},

--- a/hull3/assign/gear/M14_US.h
+++ b/hull3/assign/gear/M14_US.h
@@ -119,21 +119,21 @@ class M14_US {
     };
 
     class AR : Rifleman {
-        primaryWeapon = "hlc_lmg_m60";
+        primaryWeapon = "CUP_lmg_M60";
         handgunWeapon = "CUP_hgun_Colt1911";
         primaryWeaponItems[] = {};
         vestMagazines[] = {
-            {"hlc_100Rnd_762x51_T_M60E4", 2},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 2},
             {"CUP_7Rnd_45ACP_1911", 3}
         };
-        backpackMagazines[] = {{"hlc_100Rnd_762x51_T_M60E4", 5}};
+        backpackMagazines[] = {{"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 5}};
     };
 
     class AAR : Rifleman {
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_T_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
         binocular = "Binocular";
     };
@@ -157,13 +157,13 @@ class M14_US {
     };
 
     class MMGG : Rifleman {
-        primaryWeapon = "hlc_lmg_m60";
+        primaryWeapon = "CUP_lmg_M60";
         primaryWeaponItems[] = {};
-        vestMagazines[] = {{"hlc_100Rnd_762x51_M_M60E4", 1}};
+        vestMagazines[] = {{"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 1}};
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
     };
 
@@ -171,7 +171,7 @@ class M14_US {
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
         binocular = "Binocular";
         assignItems[] = {};
@@ -391,7 +391,7 @@ class M14_US {
         magazines[] = {
             {"hlc_20Rnd_762x51_B_M14", 20},
             {"hlc_20Rnd_762x51_T_M14", 10},
-            {"hlc_100Rnd_762x51_T_M60E4", 10},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 5},
             {"CUP_1Rnd_HE_M203", 10},
             {"UGL_FlareWhite_F", 5},
@@ -418,7 +418,7 @@ class M14_US {
         magazines[] = {
             {"hlc_20Rnd_762x51_B_M14", 40},
             {"hlc_20Rnd_762x51_T_M14", 20},
-            {"hlc_100Rnd_762x51_T_M60E4", 50},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 50},
             {"1Rnd_Smoke_Grenade_shell", 10},
             {"UGL_FlareWhite_F", 10},
             {"CUP_1Rnd_HE_M203", 30},
@@ -445,7 +445,7 @@ class M14_US {
         magazines[] = {
             {"hlc_20Rnd_762x51_B_M14", 40},
             {"hlc_20Rnd_762x51_T_M14", 20},
-            {"hlc_100Rnd_762x51_T_M60E4", 30},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 30},
             {"1Rnd_Smoke_Grenade_shell", 10},
             {"CUP_1Rnd_HE_M203", 20},
             {"UGL_FlareWhite_F", 10},

--- a/hull3/assign/gear/M16A1_US.h
+++ b/hull3/assign/gear/M16A1_US.h
@@ -119,21 +119,21 @@ class M16A1_US {
     };
 
     class AR : Rifleman {
-        primaryWeapon = "hlc_lmg_m60";
+        primaryWeapon = "CUP_lmg_M60";
         handgunWeapon = "CUP_hgun_Colt1911";
         primaryWeaponItems[] = {};
         vestMagazines[] = {
-            {"hlc_100Rnd_762x51_T_M60E4", 2},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 2},
             {"CUP_7Rnd_45ACP_1911", 3}
         };
-        backpackMagazines[] = {{"hlc_100Rnd_762x51_T_M60E4", 5}};
+        backpackMagazines[] = {{"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 5}};
     };
 
     class AAR : Rifleman {
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_T_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
         binocular = "Binocular";
     };
@@ -157,13 +157,13 @@ class M16A1_US {
     };
 
     class MMGG : Rifleman {
-        primaryWeapon = "hlc_lmg_m60";
+        primaryWeapon = "CUP_lmg_M60";
         primaryWeaponItems[] = {};
-        vestMagazines[] = {{"hlc_100Rnd_762x51_M_M60E4", 1}};
+        vestMagazines[] = {{"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 1}};
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
     };
 
@@ -171,7 +171,7 @@ class M16A1_US {
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
         binocular = "Binocular";
         assignItems[] = {};
@@ -391,7 +391,7 @@ class M16A1_US {
         magazines[] = {
             {"CUP_20Rnd_556x45_Stanag", 20},
             {"CUP_20Rnd_556x45_Stanag_Tracer_Red", 10},
-            {"hlc_100Rnd_762x51_T_M60E4", 10},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 5},
             {"CUP_1Rnd_HE_M203", 10},
             {"UGL_FlareWhite_F", 5},
@@ -418,7 +418,7 @@ class M16A1_US {
         magazines[] = {
             {"CUP_20Rnd_556x45_Stanag", 40},
             {"CUP_20Rnd_556x45_Stanag_Tracer_Red", 20},
-            {"hlc_100Rnd_762x51_T_M60E4", 50},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 50},
             {"1Rnd_Smoke_Grenade_shell", 10},
             {"UGL_FlareWhite_F", 10},
             {"CUP_1Rnd_HE_M203", 30},
@@ -445,7 +445,7 @@ class M16A1_US {
         magazines[] = {
             {"CUP_20Rnd_556x45_Stanag", 40},
             {"CUP_20Rnd_556x45_Stanag_Tracer_Red", 20},
-            {"hlc_100Rnd_762x51_T_M60E4", 30},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 30},
             {"1Rnd_Smoke_Grenade_shell", 10},
             {"CUP_1Rnd_HE_M203", 20},
             {"UGL_FlareWhite_F", 10},

--- a/hull3/assign/gear/M16A2_US.h
+++ b/hull3/assign/gear/M16A2_US.h
@@ -163,13 +163,13 @@ class M16A2_US {
     };
 
     class MMGG : Rifleman {
-        primaryWeapon = "hlc_lmg_m60";
+        primaryWeapon = "CUP_lmg_M60";
         primaryWeaponItems[] = {};
-        vestMagazines[] = {{"hlc_100Rnd_762x51_M_M60E4", 1}};
+        vestMagazines[] = {{"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 1}};
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
     };
 
@@ -177,7 +177,7 @@ class M16A2_US {
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
         binocular = "ACE_VectorDay";
         assignItems[] = {"ItemGPS"};
@@ -427,7 +427,7 @@ class M16A2_US {
             {"CUP_30Rnd_556x45_Stanag", 40},
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
-            {"hlc_100Rnd_762x51_M_M60E4", 10},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
             {"UGL_FlareWhite_F", 10},
             {"SatchelCharge_Remote_Mag", 5},
@@ -455,7 +455,7 @@ class M16A2_US {
             {"CUP_30Rnd_556x45_Stanag", 40},
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 20},
             {"CUP_200Rnd_TE4_Red_Tracer_556x45_M249", 20},
-            {"hlc_100Rnd_762x51_M_M60E4", 10},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
             {"UGL_FlareWhite_F", 10},
             {"MRAWS_HEAT_F", 5},

--- a/hull3/assign/gear/M16A4_ROK.h
+++ b/hull3/assign/gear/M16A4_ROK.h
@@ -166,14 +166,14 @@ class M16A4_ROK {
     };
 
     class MMGG : Rifleman {
-        primaryWeapon = "hlc_lmg_M60E4";
+        primaryWeapon = "CUP_lmg_M60E4";
         primaryWeaponItems[] = {};
         vestMagazines[] = {{"hlc_100Rnd_762x51_B_M60E4", 2}};
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
             {"hlc_100Rnd_762x51_B_M60E4", 4},
-            {"hlc_100Rnd_762x51_T_M60E4", 3}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 3}
         };
     };
 
@@ -183,7 +183,7 @@ class M16A4_ROK {
             {"SmokeShell", 1},
             {"30Rnd_556x45_Stanag_Tracer_Red", 2},
             {"hlc_100Rnd_762x51_B_M60E4", 3},
-            {"hlc_100Rnd_762x51_T_M60E4", 2}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 2}
         };
         binocular = "ACE_VectorDay";
         assignItems[] = {"ItemGPS"};

--- a/hull3/assign/gear/MP5_GEND.h
+++ b/hull3/assign/gear/MP5_GEND.h
@@ -162,13 +162,13 @@ class MP5_GEND {
     };
 
     class MMGG : Rifleman {
-        primaryWeapon = "hlc_lmg_m60";
+        primaryWeapon = "CUP_lmg_M60";
         primaryWeaponItems[] = {};
-        vestMagazines[] = {{"hlc_100Rnd_762x51_M_M60E4", 1}};
+        vestMagazines[] = {{"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 1}};
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
     };
 
@@ -176,7 +176,7 @@ class MP5_GEND {
         backpackMagazines[] = {
             {"HandGrenade", 1},
             {"SmokeShell", 1},
-            {"hlc_100Rnd_762x51_M_M60E4", 4}
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 4}
         };
         binocular = "ACE_VectorDay";
         assignItems[] = {"ItemGPS"};
@@ -427,7 +427,7 @@ class MP5_GEND {
             {"hlc_30Rnd_9x19_B_MP5", 40},
             {"hlc_30Rnd_9x19_GD_MP5", 20},
             {"hlc_50rnd_556x45_EPR", 20},
-            {"hlc_100Rnd_762x51_M_M60E4", 10},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
             {"UGL_FlareWhite_F", 10},
             {"SatchelCharge_Remote_Mag", 5},
@@ -455,7 +455,7 @@ class MP5_GEND {
             {"hlc_30Rnd_9x19_B_MP5", 40},
             {"hlc_30Rnd_9x19_GD_MP5", 20},
             {"hlc_50rnd_556x45_EPR", 20},
-            {"hlc_100Rnd_762x51_M_M60E4", 10},
+            {"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M", 10},
             {"1Rnd_Smoke_Grenade_shell", 10},
             {"UGL_FlareWhite_F", 10},
             {"MRAWS_HEAT_F", 5},


### PR DESCRIPTION
1:1 with current assignment of original m60 vs E4 variant, plus red tracer for everyone.