### PR TITLE
ACRE init overhaul

### DIFF
--- a/hull3/acre_functions.sqf
+++ b/hull3/acre_functions.sqf
@@ -10,7 +10,7 @@
 
 
 hull3_acre_fnc_preInit = {
-    [] call hull3_acre_fnc_addEventHandlers;
+    call hull3_acre_fnc_addEventHandlers;
     hull3_acre_isInitialized = false;
     DEBUG("hull3.acre","ACRE functions preInit finished.");
 };
@@ -22,9 +22,9 @@ hull3_acre_fnc_addEventHandlers = {
 };
 
 hull3_acre_fnc_postInit = {
-    [] call hull3_acre_fnc_setupPresets;
-    [] call hull3_acre_fnc_addLanguages;
-    [] spawn hull3_acre_fnc_acreInit;
+    call hull3_acre_fnc_setupPresets;
+    call hull3_acre_fnc_addLanguages;
+    call hull3_acre_fnc_acreInit;
 };
 
 hull3_acre_fnc_acreInit = {
@@ -32,39 +32,28 @@ hull3_acre_fnc_acreInit = {
     if (!hasInterface) exitWith {
         DEBUG("hull3.acre.init","Player is an HC, ACRE check ommited.");
     };
-    if (didJIP) then {
-        DEBUG("hull3.acre.init","Client JIPd, waiting for player to initialize.");
-        uiSleep 15;
-        waitUntil { uiSleep 0.2; !isNull player; };
-    };
-    if (!alive player) exitWith {
-        DEBUG("hull.acre.init","Player is dead, setting ACRE spectator to 'true'.");
-        [true] call acre_api_fnc_setSpectator;
-    };
-    DEBUG("hull.acre.init","Player is alive, starting ACRE init check.");
-    [false] call acre_api_fnc_setSpectator;
-    [0.7] call acre_api_fnc_setSelectableVoiceCurve;
-    DEBUG("hull.acre.init","ACRE Spectator set to 'false'.");
-    waitUntil {
-        DEBUG("hull.acre.init","Waiting for ACRE to replace 'ItemRadio'.");
-        uiSleep 1;
-        !("ItemRadio" in items player) && {!("ItemRadio" in assignedItems player)};
-    };
-    uiSleep 1;
-    waitUntil { [] call acre_api_fnc_isInitialized; };
-    DEBUG("hull.acre.init","ACRE initialized.");
-    [player] call hull3_gear_fnc_tryAssignRadios;
-    DEBUG("hull.acre.init",FMT_1("Radios assigned to '%1'.",player));
-    hull3_acre_isInitialized = true;
-    ["acre.initialized", [player]] call hull3_event_fnc_emitEvent;
-    waitUntil { [] call acre_api_fnc_isInitialized; };
-    [player] call hull3_acre_fnc_setRadioChannels;
-    player globalChat "ACRE2 radios and channels have been assigned.";
-    DEBUG("hull.acre.init","Hull3 ACRE init finished.");
+
+    [
+        {call acre_api_fnc_isInitialized},
+        {
+            DEBUG("hull.acre.init","ACRE initialized.");
+            if (!alive player) exitWith {
+                DEBUG("hull.acre.init","Player is dead, setting ACRE spectator to 'true'.");
+                true call acre_api_fnc_setSpectator;
+            };
+            DEBUG("hull.acre.init","Player is alive, starting ACRE init check.");
+            player call hull3_gear_fnc_tryAssignRadios;
+            DEBUG("hull.acre.init",FMT_1("Radios assigned to '%1'.",player));
+            hull3_acre_isInitialized = true;
+            ["acre.initialized", [player]] call hull3_event_fnc_emitEvent;
+            player call hull3_acre_fnc_setRadioChannels;
+            DEBUG("hull.acre.init","Hull3 ACRE init finished.");
+        }
+    ] call CBA_fnc_waitUntilAndExecute;
 };
 
 hull3_acre_fnc_addLanguages = {
-    DECLARE(_languages) = ["ACRE", "Babel", "languages"] call hull3_config_fnc_getArray;
+    private _languages = ["ACRE", "Babel", "languages"] call hull3_config_fnc_getArray;
     {
         _x call acre_api_fnc_babelAddLanguageType;
         DEBUG("hull3.acre.babel",FMT_2("Added language with ID '%1' and name '%2'.",_x select 0,_x select 1));
@@ -72,15 +61,14 @@ hull3_acre_fnc_addLanguages = {
 };
 
 hull3_acre_fnc_setSpokenLanguages = {
-    FUN_ARGS_1(_unit);
+    params ["_unit"];
 
-    private ["_factionLanguages", "_unitLanguages", "_languages", "_spokenLanguages"];
-    _factionLanguages = [FACTION_CONFIG, _unit getVariable ["hull3_faction", DEFAULT_FACTION_NAME], "languages"] call hull3_config_fnc_getBothArray;
-    _unitLanguages = [_unit getVariable ["hull3_init_entries", []], "languages"] call hull3_config_fnc_getEntry;
-    _languages = [];
+    private _factionLanguages = [FACTION_CONFIG, _unit getVariable ["hull3_faction", DEFAULT_FACTION_NAME], "languages"] call hull3_config_fnc_getBothArray;
+    private _unitLanguages = [_unit getVariable ["hull3_init_entries", []], "languages"] call hull3_config_fnc_getEntry;
+    private _languages = [];
     PUSH_ALL(_languages,_factionLanguages);
     PUSH_ALL(_languages,_unitLanguages);
-    _spokenLanguages = [];
+    private _spokenLanguages = [];
     {
         if ((floor random 100) + 1 <= _x select 1) then {
             PUSH(_spokenLanguages,_x select 0);
@@ -91,8 +79,8 @@ hull3_acre_fnc_setSpokenLanguages = {
 };
 
 hull3_acre_fnc_setupPresets = {
-    [] call hull3_acre_fnc_setupSidePresets;
-    [] call hull3_acre_fnc_setupUserPresets;
+    call hull3_acre_fnc_setupSidePresets;
+    call hull3_acre_fnc_setupUserPresets;
 };
 
 hull3_acre_fnc_setupSidePresets = {
@@ -103,78 +91,73 @@ hull3_acre_fnc_setupSidePresets = {
 };
 
 hull3_acre_fnc_setupUserPresets = {
-    private ["_shortRangeRadios", "_longRangeRadios", "_radios", "_presetName"];
-    _shortRangeRadios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
-    _longRangeRadios = ["ACRE", "LongRange", "radios"] call hull3_config_fnc_getArray;
-    _radios = [];
+    private _shortRangeRadios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
+    private _longRangeRadios = ["ACRE", "LongRange", "radios"] call hull3_config_fnc_getArray;
+    private _radios = [];
     PUSH_ALL(_radios,_shortRangeRadios);
     PUSH_ALL(_radios,_longRangeRadios);
-    _presetName = toLower str side player;
+    private _presetName = toLower str side player;
     {
         [_x, _presetName] call acre_api_fnc_setPreset;
     } foreach _radios;
 };
 
 hull3_acre_fnc_setupSideShortRangePreset = {
-    FUN_ARGS_1(_side);
+    params ["_side"];
 
-    private ["_baseFrequency", "_channelStep", "_sideStep", "_presetName", "_radios"];
-    _baseFrequency = ["ACRE", "ShortRange", "baseFrequency"] call hull3_config_fnc_getNumber;
-    _channelStep = ["ACRE", "Steps", "channel"] call hull3_config_fnc_getNumber;
-    _sideStep = [_side] call hull3_acre_fnc_getSideStep;
-    _presetName = toLower str _side;
-    _radios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
+    private _baseFrequency = ["ACRE", "ShortRange", "baseFrequency"] call hull3_config_fnc_getNumber;
+    private _channelStep = ["ACRE", "Steps", "channel"] call hull3_config_fnc_getNumber;
+    private _sideStep = [_side] call hull3_acre_fnc_getSideStep;
+    private _presetName = toLower str _side;
+    private _radios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
     {
         [_x, _baseFrequency, _channelStep, _sideStep, _presetName, {}, []] call hull3_acre_fnc_setRadioPresetFrequencies;
     } foreach _radios;
 };
 
 hull3_acre_fnc_setupSideLongRangePreset = {
-    FUN_ARGS_1(_side);
+    params ["_side"];
 
-    private ["_baseFrequency", "_channelStep", "_sideStep", "_presetName", "_radios"];
-    _baseFrequency = ["ACRE", "LongRange", "baseFrequency"] call hull3_config_fnc_getNumber;
-    _channelStep = ["ACRE", "Steps", "channel"] call hull3_config_fnc_getNumber;
-    _sideStep = [_side] call hull3_acre_fnc_getSideStep;
-    _presetName = toLower str _side;
-    _radios = ["ACRE", "LongRange", "radios"] call hull3_config_fnc_getArray;
-    _channelNames = ["ACRE", "LongRange", "channelNames"] call hull3_config_fnc_getArray;
+    private _baseFrequency = ["ACRE", "LongRange", "baseFrequency"] call hull3_config_fnc_getNumber;
+    private _channelStep = ["ACRE", "Steps", "channel"] call hull3_config_fnc_getNumber;
+    private _sideStep = [_side] call hull3_acre_fnc_getSideStep;
+    private _presetName = toLower str _side;
+    private _radios = ["ACRE", "LongRange", "radios"] call hull3_config_fnc_getArray;
+    private _channelNames = ["ACRE", "LongRange", "channelNames"] call hull3_config_fnc_getArray;
     {
         [_x, _baseFrequency, _channelStep, _sideStep, _presetName, hull3_acre_fnc_setLongRangeRadioFields, [_x, _presetName, _channelNames]] call hull3_acre_fnc_setRadioPresetFrequencies;
     } foreach _radios;
 };
 
 hull3_acre_fnc_setRadioPresetFrequencies = {
-    FUN_ARGS_7(_radio,_baseFrequency,_channelStep,_sideStep,_presetName,_fieldFunc,_fieldFuncArgs);
+    params ["_radio","_baseFrequency","_channelStep","_sideStep","_presetName","_fieldFunc","_fieldFuncArgs"];
 
-    DECLARE(_channelCount) = ["ACRE", "Radio", _radio, "channelCount"] call hull3_config_fnc_getNumber;
+    private _channelCount = ["ACRE", "Radio", _radio, "channelCount"] call hull3_config_fnc_getNumber;
     [_radio, "default", _presetName] call acre_api_fnc_copyPreset;
     for "_i" from 0 to (_channelCount - 1) do {
-        private ["_frequency", "_channelIndex"];
-        _frequency = _baseFrequency + _i * _channelStep + _sideStep;
-        _channelIndex = _i + 1;
+        private _frequency = _baseFrequency + _i * _channelStep + _sideStep;
+        private _channelIndex = _i + 1;
         [_radio, _presetName, _channelIndex, "frequencyTX", _frequency] call acre_api_fnc_setPresetChannelField;
         TRACE("hull3.acre.radio.preset",FMT_4("Set 'frequencyTX' field to '%1' of channel '%2' in preset '%3' of radio '%4'.",_frequency,_channelIndex,_presetName,_radio));
         [_radio, _presetName, _channelIndex, "frequencyRX", _frequency] call acre_api_fnc_setPresetChannelField;
         TRACE("hull3.acre.radio.preset",FMT_4("Set 'frequencyRX' field to '%1' of channel '%2' in preset '%3' of radio '%4'.",_frequency,_channelIndex,_presetName,_radio));
-        DECLARE(_newFieldFuncArgs) = +_fieldFuncArgs;
+        private _newFieldFuncArgs = +_fieldFuncArgs;
         PUSH(_newFieldFuncArgs,_i);
         _newFieldFuncArgs call _fieldFunc;
     };
 };
 
 hull3_acre_fnc_setLongRangeRadioFields = {
-    FUN_ARGS_4(_radio,_presetName,_channelNames,_channelArrayIndex);
+    params ["_radio","_presetName","_channelNames","_channelArrayIndex"];
 
-    private ["_channelNameField", "_channelName", "_power", "_channelIndex"];
-    _channelNameField = ["ACRE", "Radio", _radio, "channelNameField"] call hull3_config_fnc_getText;
-    _channelName = if (_channelArrayIndex < count _channelNames) then {
+    private _channelNameField = ["ACRE", "Radio", _radio, "channelNameField"] call hull3_config_fnc_getText;
+    private _channelName = if (_channelArrayIndex < count _channelNames) then {
         _channelNames select _channelArrayIndex
     } else {
         format ["%1 %2", toLower str _side, _channelArrayIndex + 1]
     };
-    _power = ["ACRE", "Radio", _x, "power"] call hull3_config_fnc_getNumber;
-    _channelIndex = _channelArrayIndex + 1;
+    private _power = ["ACRE", "Radio", _x, "power"] call hull3_config_fnc_getNumber;
+    private _channelIndex = _channelArrayIndex + 1;
     [_radio, _presetName, _channelIndex, _channelNameField, _channelName] call acre_api_fnc_setPresetChannelField;
     TRACE("hull3.acre.radio.preset",FMT_5("Set '%1' field to '%2' of channel '%3' in preset '%4' of radio '%5'.",_channelNameField,_channelName,_channelIndex,_presetName,_radio));
     [_radio, _presetName, _channelIndex, "power", _power] call acre_api_fnc_setPresetChannelField;
@@ -182,7 +165,7 @@ hull3_acre_fnc_setLongRangeRadioFields = {
 };
 
 hull3_acre_fnc_getSideStep = {
-    FUN_ARGS_1(_side);
+    params ["_side"];
 
     call {
         if (_side == WEST) exitWith {["ACRE", "Steps", "west"] call hull3_config_fnc_getNumber};
@@ -193,48 +176,52 @@ hull3_acre_fnc_getSideStep = {
 };
 
 hull3_acre_fnc_setRadioChannels = {
-    FUN_ARGS_1(_unit);
+    params ["_unit"];
 
-    private ["_defaultShortRangeChannel", "_shortRangeChannelAssignments", "_shortRangeRadios", "_defaultLongRangeChannel", "_longRangeChannelAssignments"];
-    _defaultShortRangeChannel = ["ACRE", "ShortRange", "defaultChannel"] call hull3_config_fnc_getNumber;
-    _shortRangeChannelAssignments = ["ACRE", "ShortRange", "channels"] call hull3_config_fnc_getBothArray;
-    _shortRangeRadios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
-    _defaultLongRangeChannel = ["ACRE", "LongRange", "defaultChannel"] call hull3_config_fnc_getNumber;
-    _longRangeChannelAssignments = ["ACRE", "LongRange", "channels"] call hull3_config_fnc_getBothArray;
-    {
-        private ["_channelAssignments", "_defaultChannel", "_channel"];
-        if (([_x] call acre_api_fnc_getBaseRadio) in _shortRangeRadios) then {
-            _channelAssignments = _shortRangeChannelAssignments;
-            _defaultChannel = _defaultShortRangeChannel;
-        } else {
-            _channelAssignments = _longRangeChannelAssignments;
-            _defaultChannel = _defaultLongRangeChannel;
-        };
-        _channel = [_unit, _channelAssignments, _defaultChannel] call hull3_acre_fnc_getRadioChannelFromGroupId;
-        [_x, _channel] call acre_api_fnc_setRadioChannel;
-    } foreach ([] call acre_api_fnc_getCurrentRadioList);
-    ["acre.channels.set", [player]] call hull3_event_fnc_emitEvent;
+    [
+        {(_this #0) getVariable ["hull3_gear_radiosAssigned", false] && {call acre_api_fnc_isInitialized} },
+        {
+            private _defaultShortRangeChannel = ["ACRE", "ShortRange", "defaultChannel"] call hull3_config_fnc_getNumber;
+            private _shortRangeChannelAssignments = ["ACRE", "ShortRange", "channels"] call hull3_config_fnc_getBothArray;
+            private _shortRangeRadios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
+            private _defaultLongRangeChannel = ["ACRE", "LongRange", "defaultChannel"] call hull3_config_fnc_getNumber;
+            private _longRangeChannelAssignments = ["ACRE", "LongRange", "channels"] call hull3_config_fnc_getBothArray;
+            private ["_channelAssignments", "_defaultChannel"];
+            {
+                if (([_x] call acre_api_fnc_getBaseRadio) in _shortRangeRadios) then {
+                    _channelAssignments = _shortRangeChannelAssignments;
+                    _defaultChannel = _defaultShortRangeChannel;
+                } else {
+                    _channelAssignments = _longRangeChannelAssignments;
+                    _defaultChannel = _defaultLongRangeChannel;
+                };
+                private _channel = [(_this #0), _channelAssignments, _defaultChannel] call hull3_acre_fnc_getRadioChannelFromGroupId;
+                [_x, _channel] call acre_api_fnc_setRadioChannel;
+            } foreach ([] call acre_api_fnc_getCurrentRadioList);
+            ["acre.channels.set", [(_this #0)]] call hull3_event_fnc_emitEvent;
+            (_this #0) globalChat "ACRE2 radios and channels have been assigned.";
+        },
+        [_unit]
+    ] call CBA_fnc_waitUntilAndExecute;
 };
 
 hull3_acre_fnc_getRadioChannelFromGroupId = {
-    FUN_ARGS_3(_unit,_channelAssignments,_defaultChannel);
+    params ["_unit","_channelAssignments","_defaultChannel"];
 
     TRACE("hull3.acre.radio.channel",FMT_3("Getting channel for unit '%1' with assingments '%2' and default chanel '%3'.",_unit,_channelAssignments,_defaultChannel));
-    private ["_groupId", "_channels"];
-    _groupId = groupId group _unit;
-    _channels = _channelAssignments select { _x select 0 == _groupId };
+    private _groupId = groupId group _unit;
+    private _channels = _channelAssignments select { _x select 0 == _groupId };
     TRACE("hull3.acre.radio.channel",FMT_2("Found channels are '%1' for groupId '%2'.",_channels,_groupId));
 
     call {
-        private ["_channel", "_groupIdArray", "_firstCharChannels", "_groupIdWithoutFirstChar"];
         if (count _channels > 0) exitWith { _channels select 0 select 1 };
 
-        _groupIdArray = toArray _groupId;
+        private _groupIdArray = toArray _groupId;
         if (count _groupIdArray == 0) exitWith { _defaultChannel };
 
         // For SLs and FTs we user the first character of the _groupId to find the channel.
-        _firstCharChannels = _channelAssignments select { _x select 0 == toString [_groupIdArray select 0] };
-        _groupIdWithoutFirstChar = toString (_groupIdArray select [1, count _groupIdArray - 1]);
+        private _firstCharChannels = _channelAssignments select { _x select 0 == toString [_groupIdArray select 0] };
+        private _groupIdWithoutFirstChar = toString (_groupIdArray select [1, count _groupIdArray - 1]);
         TRACE("hull3.acre.radio.channel",FMT_4("_firstCharChannels is '%1', _groupIdWithoutFirstChar is '%2', parsed number is '%3' for groupId '%4'.",_firstCharChannels,_groupIdWithoutFirstChar,parseNumber _groupIdWithoutFirstChar,_groupId));
         // FTs have a number as a second character.
         if (count _firstCharChannels > 0 && {count _groupIdArray >= 2} && {parseNumber _groupIdWithoutFirstChar >= 1}) exitWith { _firstCharChannels select 0 select 1 };
@@ -242,7 +229,7 @@ hull3_acre_fnc_getRadioChannelFromGroupId = {
         if (count _firstCharChannels > 0 && {count _groupIdArray == 3} && {_groupIdWithoutFirstChar == "SL"}) exitWith { _firstCharChannels select 0 select 1 };
 
         // We try to find matching channel assignments by using the first _n characters of the groupId plus the group number, up to 5 characters.
-        _channel = for "_i" from 2 to 5 do {
+        private _channel = for "_i" from 2 to 5 do {
             private ["_n", "_groupIdFirstNChars", "_nCharsChannels", "_groupIdWithoutFirstNChars"];
             _n = _i;
             _groupIdFirstNChars = toString (_groupIdArray select [0, _n]);

--- a/hull3/acre_functions.sqf
+++ b/hull3/acre_functions.sqf
@@ -181,6 +181,7 @@ hull3_acre_fnc_setRadioChannels = {
     [
         {(_this #0) getVariable ["hull3_gear_radiosAssigned", false] && {call acre_api_fnc_isInitialized} },
         {
+            private _unit = (_this #0);
             private _defaultShortRangeChannel = ["ACRE", "ShortRange", "defaultChannel"] call hull3_config_fnc_getNumber;
             private _shortRangeChannelAssignments = ["ACRE", "ShortRange", "channels"] call hull3_config_fnc_getBothArray;
             private _shortRangeRadios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
@@ -197,12 +198,12 @@ hull3_acre_fnc_setRadioChannels = {
                     _channelAssignments = _longRangeChannelAssignments;
                     _defaultChannel = _defaultLongRangeChannel;
                 };
-                private _channel = [(_this #0), _channelAssignments, _defaultChannel] call hull3_acre_fnc_getRadioChannelFromGroupId;
+                private _channel = [_unit, _channelAssignments, _defaultChannel] call hull3_acre_fnc_getRadioChannelFromGroupId;
                 [_x, _channel] call acre_api_fnc_setRadioChannel;
             } foreach (call acre_api_fnc_getCurrentRadioList);
 
-            ["acre.channels.set", [(_this #0)]] call hull3_event_fnc_emitEvent;
-            (_this #0) globalChat "ACRE2 radios and channels have been assigned.";
+            ["acre.channels.set", [_unit] call hull3_event_fnc_emitEvent;
+            _unit globalChat "ACRE2 radios and channels have been assigned.";
         },
         [_unit]
     ] call CBA_fnc_waitUntilAndExecute;

--- a/hull3/acre_functions.sqf
+++ b/hull3/acre_functions.sqf
@@ -186,6 +186,8 @@ hull3_acre_fnc_setRadioChannels = {
             private _shortRangeRadios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
             private _defaultLongRangeChannel = ["ACRE", "LongRange", "defaultChannel"] call hull3_config_fnc_getNumber;
             private _longRangeChannelAssignments = ["ACRE", "LongRange", "channels"] call hull3_config_fnc_getBothArray;
+            TRACE("hull3.acre.radio.assigned",FMT_2("Unit '%1' has '%2' radios assigned, attempting to set channels now.",(_this #0),call acre_api_fnc_getCurrentRadioList));
+
             private ["_channelAssignments", "_defaultChannel"];
             {
                 if (([_x] call acre_api_fnc_getBaseRadio) in _shortRangeRadios) then {
@@ -197,7 +199,8 @@ hull3_acre_fnc_setRadioChannels = {
                 };
                 private _channel = [(_this #0), _channelAssignments, _defaultChannel] call hull3_acre_fnc_getRadioChannelFromGroupId;
                 [_x, _channel] call acre_api_fnc_setRadioChannel;
-            } foreach ([] call acre_api_fnc_getCurrentRadioList);
+            } foreach (call acre_api_fnc_getCurrentRadioList);
+
             ["acre.channels.set", [(_this #0)]] call hull3_event_fnc_emitEvent;
             (_this #0) globalChat "ACRE2 radios and channels have been assigned.";
         },

--- a/hull3/acre_functions.sqf
+++ b/hull3/acre_functions.sqf
@@ -187,7 +187,7 @@ hull3_acre_fnc_setRadioChannels = {
             private _shortRangeRadios = ["ACRE", "ShortRange", "radios"] call hull3_config_fnc_getArray;
             private _defaultLongRangeChannel = ["ACRE", "LongRange", "defaultChannel"] call hull3_config_fnc_getNumber;
             private _longRangeChannelAssignments = ["ACRE", "LongRange", "channels"] call hull3_config_fnc_getBothArray;
-            TRACE("hull3.acre.radio.assigned",FMT_2("Unit '%1' has '%2' radios assigned, attempting to set channels now.",(_this #0),call acre_api_fnc_getCurrentRadioList));
+            TRACE("hull3.acre.radio.assigned",FMT_2("Unit '%1' has '%2' radios assigned, attempting to set channels now.",_unit,call acre_api_fnc_getCurrentRadioList));
 
             private ["_channelAssignments", "_defaultChannel"];
             {

--- a/hull3/gear_functions.sqf
+++ b/hull3/gear_functions.sqf
@@ -273,20 +273,20 @@ hull3_gear_fnc_assignVehicleItems = {
 };
 
 hull3_gear_fnc_tryAssignRadios = {
-    FUN_ARGS_1(_unit);
+    params ["_unit"];
 
     if (_unit getVariable ["hull3_gear_radiosAssigned", false]) exitWith {};
-    private ["_gearTemplate", "_gearClass"];
-    _gearTemplate = _unit getVariable ["hull3_gear_template", DEFAULT_TEMPLATE_NAME];
-    _gearClass = _unit getVariable ["hull3_gear_class", hull3_gear_unitBaseClass];
+
+    private _gearTemplate = _unit getVariable ["hull3_gear_template", DEFAULT_TEMPLATE_NAME];
+    private _gearClass = _unit getVariable ["hull3_gear_class", hull3_gear_unitBaseClass];
     [_unit] call hull3_gear_fnc_removeRadios;
-    DECLARE(_assignables) = [
+    private _assignables = [
         ["uniformRadios",           CONFIG_TYPE_ARRAY,      "uniform",                  ASSIGN_UNIFORM_ITEM_FUNC,           CAN_ASSIGN_UNIFORM_ITEM_FUNC,           hull3_gear_fnc_assignSingleItemArray],
         ["vestRadios",              CONFIG_TYPE_ARRAY,      "vest",                     ASSIGN_VEST_ITEM_FUNC,              CAN_ASSIGN_VEST_ITEM_FUNC,              hull3_gear_fnc_assignSingleItemArray],
         ["backpackRadios",          CONFIG_TYPE_ARRAY,      "backpack",                 ASSIGN_BACKPACK_ITEM_FUNC,          CAN_ASSIGN_BACKPACK_ITEM_FUNC,          hull3_gear_fnc_assignSingleItemArray]
     ];
     {
-        DECLARE(_configValue) = [TYPE_CLASS_GEAR, _gearTemplate, _gearClass, _x select 0] call (CONFIG_TYPE_FUNCTIONS select (_x select 1));
+        private _configValue = [TYPE_CLASS_GEAR, _gearTemplate, _gearClass, _x select 0] call (CONFIG_TYPE_FUNCTIONS select (_x select 1));
         // ADD ACRE2 preset stuff here?
         [_x select 0, _unit, _configValue, _x select 2, _x select 3, _x select 4, _gearTemplate, _gearClass] call (_x select 5);
     } foreach _assignables;
@@ -296,9 +296,13 @@ hull3_gear_fnc_tryAssignRadios = {
 };
 
 hull3_gear_fnc_removeRadios = {
-    FUN_ARGS_1(_unit);
+    params ["_unit"];
 
     private _radios = [] call acre_api_fnc_getCurrentRadioList;
+    if (_radios isEqualTo []) exitWith {
+        DEBUG("hull3.gear.assign.acre",FMT_1("No radios required removing for '%1'.",_unit));
+    };
+
     DEBUG("hull3.gear.assign.acre",FMT_2("Removing radios from '%1' from unit '%2'.",_radios,_unit));
     {
         _unit removeItem _x;


### PR DESCRIPTION
Moved everything out of scheduled space to avoid potential hangs in postInit.

Tested on dedi, with JIP, no issues so far. Will need real-world testing to see if there are any other issues. For @kami- 's sanity the flow looks like this.

CBA WUAE directly in postInit that waits for ACRE to replace any `itemRadio` items. Once this is done the gear script removes any radios (slight improvement here as the code doesn't run is there are no radios on you). Then we CBA WUAE for `hull3_gear_radiosAssigned` to be true and `acre_api_fnc_isInitialized` to be true again (as it runs each time you adds radios) then we set the channels.

This is as clean as I can get it, seems to work well! 🤞 