### PR TITLE
Mass toolkit removal

### DIFF
--- a/hull3/assign/gear/AK47_NK.h
+++ b/hull3/assign/gear/AK47_NK.h
@@ -350,7 +350,6 @@ class AK47_NK {
             {"CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -423,10 +422,7 @@ class AK47_NK {
             {"CUP_PG7V_M", 2},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -458,7 +454,6 @@ class AK47_NK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -485,7 +480,6 @@ class AK47_NK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AK74MZ_RU.h
+++ b/hull3/assign/gear/AK74MZ_RU.h
@@ -365,7 +365,6 @@ class AK74MZ_RU {
             {"CUP_30Rnd_TE1_Green_Tracer_545x39_AK74M_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -438,10 +437,7 @@ class AK74MZ_RU {
             {"CUP_FlareWhite_GP25_M", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -473,7 +469,6 @@ class AK74MZ_RU {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -500,7 +495,6 @@ class AK74MZ_RU {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AK74M_RU.h
+++ b/hull3/assign/gear/AK74M_RU.h
@@ -345,7 +345,6 @@ class AK74M_RU {
             {"CUP_30Rnd_TE1_Green_Tracer_545x39_AK74M_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -414,10 +413,7 @@ class AK74M_RU {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -449,7 +445,6 @@ class AK74M_RU {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -476,7 +471,6 @@ class AK74M_RU {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AK74_DPR.h
+++ b/hull3/assign/gear/AK74_DPR.h
@@ -362,7 +362,6 @@ class AK74_DPR {
             {"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -431,10 +430,7 @@ class AK74_DPR {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -466,7 +462,6 @@ class AK74_DPR {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -493,7 +488,6 @@ class AK74_DPR {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AK74_NK.h
+++ b/hull3/assign/gear/AK74_NK.h
@@ -355,7 +355,6 @@ class AK74_NK {
             {"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -428,10 +427,7 @@ class AK74_NK {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -463,7 +459,6 @@ class AK74_NK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -490,7 +485,6 @@ class AK74_NK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AK74_RU.h
+++ b/hull3/assign/gear/AK74_RU.h
@@ -357,7 +357,6 @@ class AK74_RU {
             {"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -426,10 +425,7 @@ class AK74_RU {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -460,7 +456,6 @@ class AK74_RU {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -488,7 +483,6 @@ class AK74_RU {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AK74_SLA.h
+++ b/hull3/assign/gear/AK74_SLA.h
@@ -355,7 +355,6 @@ class AK74_SLA {
             {"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -428,10 +427,7 @@ class AK74_SLA {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -463,7 +459,6 @@ class AK74_SLA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -490,7 +485,6 @@ class AK74_SLA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AK74_TKA.h
+++ b/hull3/assign/gear/AK74_TKA.h
@@ -366,7 +366,6 @@ class AK74_TKA {
             {"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -439,10 +438,7 @@ class AK74_TKA {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -474,7 +470,6 @@ class AK74_TKA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -501,7 +496,6 @@ class AK74_TKA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AK74_UKR.h
+++ b/hull3/assign/gear/AK74_UKR.h
@@ -364,7 +364,6 @@ class AK74_UKR {
             {"CUP_30Rnd_TE1_Red_Tracer_545x39_AK_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -433,10 +432,7 @@ class AK74_UKR {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -468,7 +464,6 @@ class AK74_UKR {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -495,7 +490,6 @@ class AK74_UKR {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKMS_LVM.h
+++ b/hull3/assign/gear/AKMS_LVM.h
@@ -345,7 +345,6 @@ class AKMS_LVM {
             {"CUP_30Rnd_TE1_Yellow_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -417,10 +416,7 @@ class AKMS_LVM {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -452,7 +448,6 @@ class AKMS_LVM {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -479,7 +474,6 @@ class AKMS_LVM {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKM_CHKDZ.h
+++ b/hull3/assign/gear/AKM_CHKDZ.h
@@ -364,7 +364,6 @@ class AKM_CHKDZ {
             {"CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -437,10 +436,7 @@ class AKM_CHKDZ {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -472,7 +468,6 @@ class AKM_CHKDZ {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -499,7 +494,6 @@ class AKM_CHKDZ {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKM_IRN.h
+++ b/hull3/assign/gear/AKM_IRN.h
@@ -367,7 +367,6 @@ class AKM_IRN {
             {"CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -440,10 +439,7 @@ class AKM_IRN {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -475,7 +471,6 @@ class AKM_IRN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -502,7 +497,6 @@ class AKM_IRN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKM_NAPA.h
+++ b/hull3/assign/gear/AKM_NAPA.h
@@ -364,7 +364,6 @@ class AKM_NAPA {
             {"CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -437,10 +436,7 @@ class AKM_NAPA {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -472,7 +468,6 @@ class AKM_NAPA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -499,7 +494,6 @@ class AKM_NAPA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKM_SLA.h
+++ b/hull3/assign/gear/AKM_SLA.h
@@ -366,7 +366,6 @@ class AKM_SLA {
             {"CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -439,10 +438,7 @@ class AKM_SLA {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -474,7 +470,6 @@ class AKM_SLA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -501,7 +496,6 @@ class AKM_SLA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKM_SYND.h
+++ b/hull3/assign/gear/AKM_SYND.h
@@ -361,7 +361,6 @@ class AKM_SYND {
             {"CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -434,10 +433,7 @@ class AKM_SYND {
             {"CUP_FlareWhite_GP25_M", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -469,7 +465,6 @@ class AKM_SYND {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -496,7 +491,6 @@ class AKM_SYND {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKM_TKI.h
+++ b/hull3/assign/gear/AKM_TKI.h
@@ -366,7 +366,6 @@ class AKM_TKI {
             {"CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -439,10 +438,7 @@ class AKM_TKI {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -474,7 +470,6 @@ class AKM_TKI {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -501,7 +496,6 @@ class AKM_TKI {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKM_TKL.h
+++ b/hull3/assign/gear/AKM_TKL.h
@@ -366,7 +366,6 @@ class AKM_TKL {
             {"CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -439,10 +438,7 @@ class AKM_TKL {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -474,7 +470,6 @@ class AKM_TKL {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -501,7 +496,6 @@ class AKM_TKL {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKS74_CDF.h
+++ b/hull3/assign/gear/AKS74_CDF.h
@@ -344,7 +344,6 @@ class AKS74_CDF {
             {"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -417,10 +416,7 @@ class AKS74_CDF {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -452,7 +448,6 @@ class AKS74_CDF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -479,7 +474,6 @@ class AKS74_CDF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AKS74_RU.h
+++ b/hull3/assign/gear/AKS74_RU.h
@@ -344,7 +344,6 @@ class AKS74_RU {
             {"CUP_30Rnd_TE1_Green_Tracer_545x39_AK74_plum_M", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -417,10 +416,7 @@ class AKS74_RU {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -452,7 +448,6 @@ class AKS74_RU {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -479,7 +474,6 @@ class AKS74_RU {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AUGA3_AUS.h
+++ b/hull3/assign/gear/AUGA3_AUS.h
@@ -342,7 +342,6 @@ class AUGA3_AUS {
             {"hlc_30Rnd_556x45_T_AUG", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -410,10 +409,7 @@ class AUGA3_AUS {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -444,7 +440,6 @@ class AUGA3_AUS {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -470,7 +465,6 @@ class AUGA3_AUS {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AUGA3_IRE.h
+++ b/hull3/assign/gear/AUGA3_IRE.h
@@ -336,7 +336,6 @@ class AUGA3_IRE {
             {"hlc_30Rnd_556x45_T_AUG", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -404,10 +403,7 @@ class AUGA3_IRE {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -438,7 +434,6 @@ class AUGA3_IRE {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -464,7 +459,6 @@ class AUGA3_IRE {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/AUGA3_NZ.h
+++ b/hull3/assign/gear/AUGA3_NZ.h
@@ -341,7 +341,6 @@ class AUGA3_NZ {
             {"hlc_30Rnd_556x45_T_AUG", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -409,10 +408,7 @@ class AUGA3_NZ {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -443,7 +439,6 @@ class AUGA3_NZ {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -469,7 +464,6 @@ class AUGA3_NZ {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/BREN2_RACS.h
+++ b/hull3/assign/gear/BREN2_RACS.h
@@ -342,7 +342,6 @@ class BREN2_RACS {
             {"CUP_30Rnd_556x45_Stanag_Tracer_Yellow", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -410,10 +409,7 @@ class BREN2_RACS {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -444,7 +440,6 @@ class BREN2_RACS {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -470,7 +465,6 @@ class BREN2_RACS {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/BREN805_CZ.h
+++ b/hull3/assign/gear/BREN805_CZ.h
@@ -353,7 +353,6 @@ class BREN805_CZ {
             {"CUP_30Rnd_TE1_Red_Tracer_556x45_CZ805", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -426,10 +425,7 @@ class BREN805_CZ {
             {"CUP_PG7VL_M", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -461,7 +457,6 @@ class BREN805_CZ {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -488,7 +483,6 @@ class BREN805_CZ {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/BREN807_PMC.h
+++ b/hull3/assign/gear/BREN807_PMC.h
@@ -356,7 +356,6 @@ class BREN807_PMC {
             {"CUP_30Rnd_TE1_Yellow_Tracer_762x39_CZ807", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -424,10 +423,7 @@ class BREN807_PMC {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -458,7 +454,6 @@ class BREN807_PMC {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -484,7 +479,6 @@ class BREN807_PMC {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/CAR95_CN.h
+++ b/hull3/assign/gear/CAR95_CN.h
@@ -364,7 +364,6 @@ class CAR95_CN {
             {"30Rnd_580x42_Mag_Tracer_F", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -437,10 +436,7 @@ class CAR95_CN {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"ItemGPS", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -472,7 +468,6 @@ class CAR95_CN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -498,7 +493,6 @@ class CAR95_CN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/CAR95_CSAT.h
+++ b/hull3/assign/gear/CAR95_CSAT.h
@@ -374,7 +374,6 @@ class CAR95_CSAT {
             {"30Rnd_580x42_Mag_Tracer_F", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -447,10 +446,7 @@ class CAR95_CSAT {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"ItemGPS", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -481,7 +477,6 @@ class CAR95_CSAT {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -507,7 +502,6 @@ class CAR95_CSAT {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/FAL_TKA.h
+++ b/hull3/assign/gear/FAL_TKA.h
@@ -339,7 +339,6 @@ class FAL_TKA {
             {"hlc_20Rnd_762x51_T_fal", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -412,10 +411,7 @@ class FAL_TKA {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -447,7 +443,6 @@ class FAL_TKA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -473,7 +468,6 @@ class FAL_TKA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/FAMAS_GEND.h
+++ b/hull3/assign/gear/FAMAS_GEND.h
@@ -329,7 +329,6 @@ class FAMAS_GEND {
             {"CUP_25Rnd_556x45_Famas_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -397,10 +396,7 @@ class FAMAS_GEND {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -431,7 +427,6 @@ class FAMAS_GEND {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -457,7 +452,6 @@ class FAMAS_GEND {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/FOW_BAF_42_G.h
+++ b/hull3/assign/gear/FOW_BAF_42_G.h
@@ -263,7 +263,6 @@ class FOW_BAF_42_G {
         primaryWeapon = "fow_w_sten_mk2";
         vestMagazines[] = {{"fow_32Rnd_9x19_sten", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -329,10 +328,7 @@ class FOW_BAF_42_G {
             {"SmokeShell", 10},
             {"fow_e_no73", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/FOW_BAF_44_G.h
+++ b/hull3/assign/gear/FOW_BAF_44_G.h
@@ -263,7 +263,6 @@ class FOW_BAF_44_G {
         primaryWeapon = "fow_w_sten_mk5";
         vestMagazines[] = {{"fow_32Rnd_9x19_sten", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -329,10 +328,7 @@ class FOW_BAF_44_G {
             {"SmokeShell", 10},
             {"fow_e_no73", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/FOW_BAF_PAC_G.h
+++ b/hull3/assign/gear/FOW_BAF_PAC_G.h
@@ -263,7 +263,6 @@ class FOW_BAF_PAC_G {
         primaryWeapon = "fow_w_sten_mk5";
         vestMagazines[] = {{"fow_32Rnd_9x19_sten", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -329,10 +328,7 @@ class FOW_BAF_PAC_G {
             {"SmokeShell", 10},
             {"fow_e_no73", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/FOW_GER_G.h
+++ b/hull3/assign/gear/FOW_GER_G.h
@@ -260,7 +260,6 @@ class FOW_GER_G {
         primaryWeapon = "fow_w_mp40";
         vestMagazines[] = {{"fow_32Rnd_9x19_mp40", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -332,10 +331,7 @@ class FOW_GER_G {
             {"SmokeShell", 10},
             {"fow_e_m24_at", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/FOW_GER_PARA_G.h
+++ b/hull3/assign/gear/FOW_GER_PARA_G.h
@@ -260,7 +260,6 @@ class FOW_GER_PARA_G {
         primaryWeapon = "fow_w_mp40";
         vestMagazines[] = {{"fow_32Rnd_9x19_mp40", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -332,10 +331,7 @@ class FOW_GER_PARA_G {
             {"SmokeShell", 10},
             {"fow_e_m24_at", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/FOW_IJA_G.h
+++ b/hull3/assign/gear/FOW_IJA_G.h
@@ -232,7 +232,6 @@ class FOW_IJA_G {
         primaryWeapon = "fow_w_type100";
         vestMagazines[] = {{"fow_32Rnd_8x22", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -301,10 +300,7 @@ class FOW_IJA_G {
             {"SmokeShell", 10},
             {"fow_e_type99_at", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/FOW_USA_G.h
+++ b/hull3/assign/gear/FOW_USA_G.h
@@ -309,7 +309,6 @@ class FOW_USA_G {
         primaryWeapon = "fow_w_m1_carbine";
         vestMagazines[] = {{"fow_15Rnd_762x33", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -387,10 +386,7 @@ class FOW_USA_G {
             {"SmokeShell", 10},
             {"fow_e_tnt_halfpound", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/FOW_USMC_G.h
+++ b/hull3/assign/gear/FOW_USMC_G.h
@@ -309,7 +309,6 @@ class FOW_USMC_G {
         primaryWeapon = "fow_w_m1_carbine";
         vestMagazines[] = {{"fow_15Rnd_762x33", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -388,10 +387,7 @@ class FOW_USMC_G {
             {"SmokeShell", 10},
             {"fow_e_tnt_halfpound", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/G36_GER.h
+++ b/hull3/assign/gear/G36_GER.h
@@ -346,7 +346,6 @@ class G36_GER {
             {"CUP_30Rnd_TE1_Red_Tracer_556x45_G36", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -415,10 +414,7 @@ class G36_GER {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -448,7 +444,6 @@ class G36_GER {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -473,7 +468,6 @@ class G36_GER {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/G3A3_IRN.h
+++ b/hull3/assign/gear/G3A3_IRN.h
@@ -332,7 +332,6 @@ class G3A3_IRN {
             {"CUP_20Rnd_TE1_Green_Tracer_762x51_G3", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -403,10 +402,7 @@ class G3A3_IRN {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -435,7 +431,6 @@ class G3A3_IRN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -458,7 +453,6 @@ class G3A3_IRN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/HK416_CTRG_BLK.h
+++ b/hull3/assign/gear/HK416_CTRG_BLK.h
@@ -347,7 +347,6 @@ class HK416_CTRG_BLK {
             {"30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -415,10 +414,7 @@ class HK416_CTRG_BLK {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -449,7 +445,6 @@ class HK416_CTRG_BLK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -475,7 +470,6 @@ class HK416_CTRG_BLK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/HK416_KSK.h
+++ b/hull3/assign/gear/HK416_KSK.h
@@ -346,7 +346,6 @@ class HK416_KSK {
             {"CUP_30Rnd_556x45_Emag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -414,10 +413,7 @@ class HK416_KSK {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -447,7 +443,6 @@ class HK416_KSK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -472,7 +467,6 @@ class HK416_KSK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/HK416_NOR.h
+++ b/hull3/assign/gear/HK416_NOR.h
@@ -347,7 +347,6 @@ class HK416_NOR {
             {"CUP_30Rnd_556x45_PMAG_QP_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -420,10 +419,7 @@ class HK416_NOR {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -454,7 +450,6 @@ class HK416_NOR {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -480,7 +475,6 @@ class HK416_NOR {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/HK416_ROK.h
+++ b/hull3/assign/gear/HK416_ROK.h
@@ -360,7 +360,6 @@ class HK416_ROK {
             {"CUP_30Rnd_556x45_PMAG_QP_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -432,10 +431,7 @@ class HK416_ROK {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -466,7 +462,6 @@ class HK416_ROK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -492,7 +487,6 @@ class HK416_ROK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/IF44_BAF_42_G.h
+++ b/hull3/assign/gear/IF44_BAF_42_G.h
@@ -259,7 +259,6 @@ class IF44_BAF_42_G {
         primaryWeapon = "LIB_Sten_Mk2";
         vestMagazines[] = {{"LIB_32Rnd_9x19_Sten", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -324,10 +323,7 @@ class IF44_BAF_42_G {
             {"SmokeShell", 10},
             {"LIB_No82", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/IF44_BAF_44_G.h
+++ b/hull3/assign/gear/IF44_BAF_44_G.h
@@ -259,7 +259,6 @@ class IF44_BAF_44_G {
         primaryWeapon = "LIB_Sten_Mk5";
         vestMagazines[] = {{"LIB_32Rnd_9x19_Sten", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -324,10 +323,7 @@ class IF44_BAF_44_G {
             {"SmokeShell", 10},
             {"LIB_No82", 25}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/IF44_GER_42_G.h
+++ b/hull3/assign/gear/IF44_GER_42_G.h
@@ -279,7 +279,6 @@ class IF44_GER_42_G {
         primaryWeapon = "LIB_MP40";
         vestMagazines[] = {{"LIB_32Rnd_9x19", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -356,10 +355,7 @@ class IF44_GER_42_G {
             {"LIB_1Rnd_81mm_Mo_Smoke", 15},
             {"LIB_1Rnd_81mm_Mo_Illum", 15}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/IF44_GER_43_G.h
+++ b/hull3/assign/gear/IF44_GER_43_G.h
@@ -279,7 +279,6 @@ class IF44_GER_43_G {
         primaryWeapon = "LIB_MP40";
         vestMagazines[] = {{"LIB_32Rnd_9x19", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -357,10 +356,7 @@ class IF44_GER_43_G {
             {"LIB_1Rnd_81mm_Mo_Smoke", 15},
             {"LIB_1Rnd_81mm_Mo_Illum", 15}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/IF44_GER_PARA_G.h
+++ b/hull3/assign/gear/IF44_GER_PARA_G.h
@@ -279,7 +279,6 @@ class IF44_GER_PARA_G {
         primaryWeapon = "LIB_MP40";
         vestMagazines[] = {{"LIB_32Rnd_9x19", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -357,10 +356,7 @@ class IF44_GER_PARA_G {
             {"LIB_1Rnd_81mm_Mo_Smoke", 15},
             {"LIB_1Rnd_81mm_Mo_Illum", 15}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/IF44_USA_G.h
+++ b/hull3/assign/gear/IF44_USA_G.h
@@ -292,7 +292,6 @@ class IF44_USA_G {
         primaryWeapon = "LIB_M1A1_Thompson";
         vestMagazines[] = {{"LIB_30Rnd_45ACP", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -366,10 +365,7 @@ class IF44_USA_G {
             {"LIB_1Rnd_60mm_Mo_Smoke", 15},
             {"LIB_1Rnd_60mm_Mo_Illum", 15}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/IF44_USA_PARA_G.h
+++ b/hull3/assign/gear/IF44_USA_PARA_G.h
@@ -292,7 +292,6 @@ class IF44_USA_PARA_G {
         primaryWeapon = "LIB_M1A1_Thompson";
         vestMagazines[] = {{"LIB_30Rnd_45ACP", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -366,10 +365,7 @@ class IF44_USA_PARA_G {
             {"LIB_1Rnd_60mm_Mo_Smoke", 15},
             {"LIB_1Rnd_60mm_Mo_Illum", 15}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/IF44_USSR_G.h
+++ b/hull3/assign/gear/IF44_USSR_G.h
@@ -256,7 +256,6 @@ class IF44_USSR_G {
         primaryWeapon = "LIB_PPSh41_m";
         vestMagazines[] = {{"LIB_71Rnd_762x25", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 5}
         };
         assignItems[] = {};
@@ -330,10 +329,7 @@ class IF44_USSR_G {
             {"LIB_1Rnd_82mm_Mo_Smoke", 15},
             {"LIB_1Rnd_82mm_Mo_Illum", 15}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         radios[] = {
             {"ACRE_PRC343", 1},
             {"ACRE_PRC152", 1}

--- a/hull3/assign/gear/Katiba_CSAT.h
+++ b/hull3/assign/gear/Katiba_CSAT.h
@@ -376,7 +376,6 @@ class Katiba_CSAT {
             {"30Rnd_65x39_caseless_green_mag_Tracer", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -449,10 +448,7 @@ class Katiba_CSAT {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"ItemGPS", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -483,7 +479,6 @@ class Katiba_CSAT {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -509,7 +504,6 @@ class Katiba_CSAT {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/L85_BAF.h
+++ b/hull3/assign/gear/L85_BAF.h
@@ -340,7 +340,6 @@ class L85_BAF {
             {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -408,10 +407,7 @@ class L85_BAF {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -442,7 +438,6 @@ class L85_BAF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -468,7 +463,6 @@ class L85_BAF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/L85_BAF_RIS.h
+++ b/hull3/assign/gear/L85_BAF_RIS.h
@@ -341,7 +341,6 @@ class L85_BAF_RIS {
             {"CUP_30Rnd_556x45_Stanag_L85_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -409,10 +408,7 @@ class L85_BAF_RIS {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -443,7 +439,6 @@ class L85_BAF_RIS {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -469,7 +464,6 @@ class L85_BAF_RIS {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/M14_US.h
+++ b/hull3/assign/gear/M14_US.h
@@ -334,7 +334,6 @@ class M14_US {
             {"ACE_20Rnd_762x51_Mag_Tracer", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -403,7 +402,7 @@ class M14_US {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {{"Toolkit", 1}};
+        items[] = {};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -432,10 +431,7 @@ class M14_US {
             {"HandGrenade", 10},
             {"SmokeShell", 10}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -457,10 +453,7 @@ class M14_US {
             {"HandGrenade", 10},
             {"SmokeShell", 10}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}

--- a/hull3/assign/gear/M16A1_US.h
+++ b/hull3/assign/gear/M16A1_US.h
@@ -334,7 +334,6 @@ class M16A1_US {
             {"CUP_20Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -403,7 +402,7 @@ class M16A1_US {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {{"Toolkit", 1}};
+        items[] = {};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -432,10 +431,7 @@ class M16A1_US {
             {"HandGrenade", 10},
             {"SmokeShell", 10}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -457,10 +453,7 @@ class M16A1_US {
             {"HandGrenade", 10},
             {"SmokeShell", 10}
         };
-        items[] = {
-            {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1}
-        };
+        items[] = {{"ACE_M26_Clacker", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}

--- a/hull3/assign/gear/M16A2_IDF.h
+++ b/hull3/assign/gear/M16A2_IDF.h
@@ -351,7 +351,6 @@ class M16A2_IDF {
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -423,10 +422,7 @@ class M16A2_IDF {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -457,7 +453,6 @@ class M16A2_IDF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -483,7 +478,6 @@ class M16A2_IDF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/M16A2_US.h
+++ b/hull3/assign/gear/M16A2_US.h
@@ -340,7 +340,6 @@ class M16A2_US {
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -408,10 +407,7 @@ class M16A2_US {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -442,7 +438,6 @@ class M16A2_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -468,7 +463,6 @@ class M16A2_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/M16A4_CAN.h
+++ b/hull3/assign/gear/M16A4_CAN.h
@@ -352,7 +352,6 @@ class M16A4_CAN {
             {"30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -420,10 +419,7 @@ class M16A4_CAN {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -454,7 +450,6 @@ class M16A4_CAN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -480,7 +475,6 @@ class M16A4_CAN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/M16A4_ROK.h
+++ b/hull3/assign/gear/M16A4_ROK.h
@@ -354,7 +354,6 @@ class M16A4_ROK {
             {"30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -422,10 +421,7 @@ class M16A4_ROK {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -456,7 +452,6 @@ class M16A4_ROK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -482,7 +477,6 @@ class M16A4_ROK {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/M16A4_USMC.h
+++ b/hull3/assign/gear/M16A4_USMC.h
@@ -353,7 +353,6 @@ class M16A4_USMC {
             {"30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -421,10 +420,7 @@ class M16A4_USMC {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -455,7 +451,6 @@ class M16A4_USMC {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -481,7 +476,6 @@ class M16A4_USMC {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/M4A1_US.h
+++ b/hull3/assign/gear/M4A1_US.h
@@ -345,7 +345,6 @@ class M4A1_US {
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -413,10 +412,7 @@ class M4A1_US {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -447,7 +443,6 @@ class M4A1_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -473,7 +468,6 @@ class M4A1_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/M4A1_USMC.h
+++ b/hull3/assign/gear/M4A1_USMC.h
@@ -347,7 +347,6 @@ class M4A1_USMC {
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -415,10 +414,7 @@ class M4A1_USMC {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -449,7 +445,6 @@ class M4A1_USMC {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -475,7 +470,6 @@ class M4A1_USMC {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/M4_US.h
+++ b/hull3/assign/gear/M4_US.h
@@ -339,7 +339,6 @@ class M4_US {
             {"CUP_30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -407,10 +406,7 @@ class M4_US {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -441,7 +437,6 @@ class M4_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -467,7 +462,6 @@ class M4_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/MP5_GEND.h
+++ b/hull3/assign/gear/MP5_GEND.h
@@ -326,7 +326,6 @@ class MP5_GEND {
         primaryWeaponItems[] = {};
         vestMagazines[] = {{"CUP_30Rnd_9x19_MP5", 8}};
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -392,10 +391,7 @@ class MP5_GEND {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -424,7 +420,6 @@ class MP5_GEND {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -448,7 +443,6 @@ class MP5_GEND {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/MX_NATO.h
+++ b/hull3/assign/gear/MX_NATO.h
@@ -377,7 +377,6 @@ class MX_NATO {
             {"30Rnd_65x39_caseless_mag_Tracer", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -450,10 +449,7 @@ class MX_NATO {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -484,7 +480,6 @@ class MX_NATO {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -510,7 +505,6 @@ class MX_NATO {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/Mk20_AAF_WD.h
+++ b/hull3/assign/gear/Mk20_AAF_WD.h
@@ -365,7 +365,6 @@ class Mk20_AAF_WD {
             {"30Rnd_556x45_Stanag_Tracer_Yellow", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -438,10 +437,7 @@ class Mk20_AAF_WD {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -472,7 +468,6 @@ class Mk20_AAF_WD {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -498,7 +493,6 @@ class Mk20_AAF_WD {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/RK62_FIN.h
+++ b/hull3/assign/gear/RK62_FIN.h
@@ -354,7 +354,6 @@ class RK62_FIN {
             {"30Rnd_762x39_Mag_Tracer_F", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -424,10 +423,7 @@ class RK62_FIN {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -456,7 +452,6 @@ class RK62_FIN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -480,7 +475,6 @@ class RK62_FIN {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/SCAR_H_US.h
+++ b/hull3/assign/gear/SCAR_H_US.h
@@ -349,7 +349,6 @@ class SCAR_H_US {
             {"CUP_20Rnd_TE1_Red_Tracer_762x51_SCAR", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -427,10 +426,7 @@ class SCAR_H_US {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -461,7 +457,6 @@ class SCAR_H_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -487,7 +482,6 @@ class SCAR_H_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/SCAR_L_US.h
+++ b/hull3/assign/gear/SCAR_L_US.h
@@ -353,7 +353,6 @@ class SCAR_L_US {
             {"CUP_30Rnd_556x45_Stanag_Mk16_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -421,10 +420,7 @@ class SCAR_L_US {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -455,7 +451,6 @@ class SCAR_L_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -481,7 +476,6 @@ class SCAR_L_US {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/SIG550_CDF.h
+++ b/hull3/assign/gear/SIG550_CDF.h
@@ -345,7 +345,6 @@ class SIG550_CDF {
             {"hlc_30Rnd_556x45_T_sg550", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -413,10 +412,7 @@ class SIG550_CDF {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -447,7 +443,6 @@ class SIG550_CDF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -473,7 +468,6 @@ class SIG550_CDF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/TAVOR_IDF.h
+++ b/hull3/assign/gear/TAVOR_IDF.h
@@ -358,7 +358,6 @@ class TAVOR_IDF {
             {"30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -430,10 +429,7 @@ class TAVOR_IDF {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -464,7 +460,6 @@ class TAVOR_IDF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -490,7 +485,6 @@ class TAVOR_IDF {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/TRG_FIA.h
+++ b/hull3/assign/gear/TRG_FIA.h
@@ -363,7 +363,6 @@ class TRG_FIA {
             {"30Rnd_556x45_Stanag_Tracer_Red", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -432,10 +431,7 @@ class TRG_FIA {
             {"HandGrenade", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -466,7 +462,6 @@ class TRG_FIA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -492,7 +487,6 @@ class TRG_FIA {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {

--- a/hull3/assign/gear/VZ58_CZ.h
+++ b/hull3/assign/gear/VZ58_CZ.h
@@ -355,7 +355,6 @@ class VZ58_CZ {
             {"CUP_30Rnd_Sa58_M_TracerR", 2}
         };
         backpackMagazines[] = {
-            {"Toolkit", 1},
             {"DemoCharge_Remote_Mag", 3},
             {"SLAMDirectionalMine_Wire_Mag", 2}
         };
@@ -428,10 +427,7 @@ class VZ58_CZ {
             {"CUP_PG7VL_M", 5},
             {"SmokeShell", 5}
         };
-        items[] = {
-            {"Toolkit", 1},
-            {"ItemGPS", 1}
-        };
+        items[] = {{"ItemGPS", 1}};
         medicalItems[] = {
             {"ACE_fieldDressing", 50},
             {"ACE_splint", 12}
@@ -461,7 +457,6 @@ class VZ58_CZ {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {
@@ -486,7 +481,6 @@ class VZ58_CZ {
         };
         items[] = {
             {"ACE_M26_Clacker", 1},
-            {"Toolkit", 1},
             {"ItemGPS", 1}
         };
         medicalItems[] = {


### PR DESCRIPTION
No longer required for ACE repair so removing them from vehicles to avoid confusion.