### PR TITLE
Adding new public ACE safety fnc

### DIFF
--- a/hull3/mission_functions.sqf
+++ b/hull3/mission_functions.sqf
@@ -212,32 +212,19 @@ hull3_mission_fnc_clientSafetyTimerLoop = {
     if (!isNil {hull3_mission_safetyTimerEnd} && {hull3_mission_safetyTimerEnd > 0}) then {
         [] call hull3_mission_fnc_addHostSafetyTimerStopAction;
         [player] call hull3_unit_fnc_addFiredEHs;
-        [player] call hull3_unit_fnc_addAceThrowableThrownEH;
-        private _playerWeapons = [];
-
-        { 
-            if (!(_x isEqualTo "")) then { 
-                _playerWeapons pushback _x;
-            }; 
-        } forEach [primaryWeapon player,handgunWeapon player]; 
 
         DEBUG("hull3.mission.safetytimer","Starting safety timer loop.");
         [{
             params ["_args", "_id"];
-            _args params ["_playerWeapons"];
-            {
-                if (!(_x in (player getVariable ["ace_safemode_safedWeapons", []]))) then {
-                    [player, _x, _x] call ace_safemode_fnc_lockSafety;
-                };
-            } foreach _playerWeapons;
+            {[ACE_player, _x, true] call ace_safemode_fnc_setWeaponSafety} forEach (weapons player);
 
             if ([] call hull3_mission_fnc_hasSafetyTimerEnded) then {
                 [_this #1] call CBA_fnc_removePerFrameHandler;
-                player removeEventHandler ["Fired", player getVariable "hull3_eh_fired"];
-                ["ace_throwableThrown", player getVariable "hull3_eh_ace_throwableThrown"] call CBA_fnc_removeEventHandler;
+                ["ace_firedPlayer", (player getVariable "hull3_eh_fired")] call CBA_fnc_removeEventHandler;
+                {[ACE_player, _x, false] call ace_safemode_fnc_setWeaponSafety} forEach (weapons player);
                 DEBUG("hull3.mission.safetytimer","Safety timer has ended. Removed fired EH.");
             };
-        }, 0, [_playerWeapons]] call CBA_fnc_addPerFrameHandler;
+        } ] call CBA_fnc_addPerFrameHandler;
     };
 };
 

--- a/hull3/unit_functions.sqf
+++ b/hull3/unit_functions.sqf
@@ -71,11 +71,14 @@ hull3_unit_fnc_addEHs = {
 hull3_unit_fnc_addFiredEHs = {
     params ["_unit"];
 
-    private "_ehId";
-    _ehId = player addEventHandler ["Fired", {
-        [_this select 6] call ace_frag_fnc_addBlackList;
-        deleteVehicle (_this select 6);
-    }];
+    private _ehId = ["ace_firedPlayer", {
+        private _obj = param [6, objNull];
+        if (!isNil "ace_frag_fnc_addBlackList") then {
+            [_obj] call ace_frag_fnc_addBlackList;
+        };
+        deleteVehicle _obj;
+    }] call CBA_fnc_addEventHandler;
+
     _unit setVariable ["hull3_eh_fired", _ehId];
 };
 
@@ -88,17 +91,6 @@ hull3_unit_fnc_friendlyFireEH = {
     };
 
     _damage;
-};
-
-hull3_unit_fnc_addAceThrowableThrownEH = {
-    params ["_unit"];
-
-    private "_ehId";
-    _ehId = ["ace_throwableThrown", {
-        [_this select 1] call ace_frag_fnc_addBlackList;
-        deleteVehicle (_this select 1);
-    }] call CBA_fnc_addEventHandler;
-    _unit setVariable ["hull3_eh_ace_throwableThrown", _ehId];
 };
 
 hull3_unit_fnc_killedEH = {


### PR DESCRIPTION
Nice new public function checks for empty weapons so can dump our check, it also checks to see if the weapon is already set to safe and skips it so another check we can remove.

Switched to `ace_firedPlayer` EH since it picks up both standard fired EH bits plus the ACE advanced throwing (including cooking nades). Doing the check on `weapons player` covers primary, secondary and launchers so less likely to have a fuck up there.

Added bonus that we auto set weapons to fire after safety is off so no need to cycle 3 weapons manually toggling it off. Checked in SP and self-hosted and it's all fine. Functions fully local so shouldn't need a dedi test.