### PR TITLE
Fixing wind to use global command

### DIFF
--- a/hull3/mission_functions.sqf
+++ b/hull3/mission_functions.sqf
@@ -133,7 +133,7 @@ hull3_mission_fnc_setWeather = {
     _time setRain (_weather #1);
     _time setRainbow (_weather #2);
     _time setLightnings (_weather #3);
-    _time setWindStr  (_weather #4);
+    setWind [(_weather #4), (_weather #4), true];
     _time setWindForce (_weather #5);
     _time setWaves (_weather #6);
 };

--- a/hull3/mission_params.h
+++ b/hull3/mission_params.h
@@ -27,18 +27,18 @@ class MissionParams {
     // Overcast, Rain, Rainbow, Lightnings, Wind Strength, Wind Gusts, Waves
     weather[] = {
         {-1},                                                      // Random
-        
-        {0,       0,    0,    0,       0,       0,       0},       // Clear (Calm)
-        {0,       0,    0,    0,       0.25,    0.25,    0.25},    // Clear (Light Winds)
-        {0,       0,    0,    0,       0.50,    0.50,    0.50},    // Clear (Stong Winds)
-        
-        {0.48,    0,    0,    0,       0,       0,       0},       // Overcast (Calm)
-        {0.48,    0,    0,    0,       0.25,    0.25,    0.25},    // Overcast (Light Winds)
-        {0.48,    0,    0,    0,       0.50,    0.50,    0.50},    // Overcast (Strong Winds)
-        
-        {1,       1,    0,    0.25,    0.25,    0.25,    0.25},    // Rain (Light Winds)
-        {1,       1,    0,    0.50,    0.50,    0.50,    0.50},    // Rain (Strong Winds)
-        
-        {1,       1,    0,    1,       0.75,    1,       1}        // Storm
+
+        {0,       0,    0,    0,       1,     0,       0},       // Clear (Calm)
+        {0,       0,    0,    0,       5,     0,    0.25},    // Clear (Light Winds)
+        {0,       0,    0,    0,       10,    0,    0.50},    // Clear (Stong Winds)
+
+        {0.48,    0,    0,    0,       1,     0,       0},       // Overcast (Calm)
+        {0.48,    0,    0,    0,       5,     0,    0.25},    // Overcast (Light Winds)
+        {0.48,    0,    0,    0,       10,    0,    0.50},    // Overcast (Strong Winds)
+
+        {1,       1,    0,    0.25,    5,     0,    0.25},    // Rain (Light Winds)
+        {1,       1,    0,    0.50,    10,    0,    0.50},    // Rain (Strong Winds)
+
+        {1,       1,    0,    1,       20,    0,       1}        // Storm
     };
 };


### PR DESCRIPTION
Removed the use of `setWindStr` which operates in a 0..1 range for `setWind` which is m/s.

I've picked values based on their sound cues, 1m/s for "no wind" so things still move around a bit, looks weird with all the trees and grass being totally static. Only slightly effects smoke and ballistics don't care about wind. 5m/s for light, this has a slight sound with it. 10m/s for strong wind, again more intense sound. 20m/s for storm, it's pretty intense...

Wind will always blow NE as if you leave direction not forced it flicks directions erratically and does weird things. If wanted I could add another line to `setWindDir random 360` to vary this, not sure if anyone is that fussed!

Finally I've left in `setWindForce` but zero'd all the values as to not break existing missions. In an ideal world I'd remove this as it's not actually wind force, just how less windy it gets over time. I'd rather the weather values the mission maker picks actually persist for the mission and don't randomly change.

Thoughts?