### PR TITLE
Adjust Hull to use respawn type "NONE"

### DIFF
--- a/hull3.Altis/description.ext
+++ b/hull3.Altis/description.ext
@@ -15,7 +15,7 @@ class Header
     maxPlayers = 970;
 };
 
-respawn = 1;
+respawn = 0;
 respawndelay = 3;
 respawnTemplates[] = {"Hull3_RespawnHandler"};
 

--- a/hull3/config.cpp
+++ b/hull3/config.cpp
@@ -82,6 +82,7 @@ class CfgVehicles {
 };
 
 class CfgRespawnTemplates {
+    respawnTemplatesNone[] = {"Hull3_RespawnHandler"};
     class Hull3_RespawnHandler {
         onPlayerRespawn = "hull3_unit_fnc_onPlayerRespawn";
     };


### PR DESCRIPTION
ARK Inhouse takes care of moving people to spec, the Hull3 event should still fire with the suggested config changes.