### PR TITLE
Fixing nullObj being passed in entityKilled

### DIFF
--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -81,8 +81,8 @@ hull3_gc_fnc_sortDead = {
     params ["_killed"];
 
     if (isNull _killed) exitWith {};
+    if (!(_killed isKindOf "CAManBase") || { !(_killed isKindOf "Car") } || { !(_killed isKindOf "Tank") } || { !(_killed isKindOf "Air") } || { !(_killed isKindOf "Ship") } ) exitWith {};
     if (isPlayer _killed || { _killed getVariable ["hull3_gc_doNotRemove", false] } ) exitWith {};
-    if (_killed isKindOf "Logic" || { _killed isKindOf "Static" } || {  _killed isKindOf "Thing" } ) exitWith {};
 
     if (_killed isKindOf "CAManBase") then {
          hull3_gc_deadUnits pushBack _killed;

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -79,6 +79,8 @@ hull3_gc_fnc_adjustConfig = {
 
 hull3_gc_fnc_sortDead = {
     params ["_killed"];
+
+    if (isNull _killed) exitWith {};
     if (isPlayer _killed || { _killed getVariable ["hull3_gc_doNotRemove", false] } ) exitWith {};
     if (_killed isKindOf "Logic" || { _killed isKindOf "Static" } || {  _killed isKindOf "Thing" } ) exitWith {};
 

--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -81,7 +81,12 @@ hull3_gc_fnc_sortDead = {
     params ["_killed"];
 
     if (isNull _killed) exitWith {};
-    if (!(_killed isKindOf "CAManBase") || { !(_killed isKindOf "Car") } || { !(_killed isKindOf "Tank") } || { !(_killed isKindOf "Air") } || { !(_killed isKindOf "Ship") } ) exitWith {};
+    if (!(_killed isKindOf "CAManBase")
+        && { !(_killed isKindOf "Car") }
+        && { !(_killed isKindOf "Tank") }
+        && { !(_killed isKindOf "Air") }
+        && { !(_killed isKindOf "Ship") }) exitWith {};
+
     if (isPlayer _killed || { _killed getVariable ["hull3_gc_doNotRemove", false] } ) exitWith {};
 
     if (_killed isKindOf "CAManBase") then {


### PR DESCRIPTION
Not sure when this started happening but I noticed that vehicles were being deleted nearly instantly when they exploded. Looking at the array, it was filled with `<NULL-object>`.

Not sure if this is off the back of an ACE update or something but `entityKilled` is returning a lot of garbage now. Example:

```
 0:08:01 "O Charlie 3-4:3 REMOTE"
 0:08:01 "<NULL-object>"
 0:08:28 "O Charlie 2-4:1 REMOTE"
 0:08:28 "<NULL-object>"
 0:08:31 "O Charlie 1-1:2 REMOTE"
 0:08:31 "<NULL-object>"
```

or

```
 0:09:00 "2a6af13d600# 587069: zastavka_jih.p3d"
 0:09:00 "<NULL-object>"
 0:09:00 "<NULL-object>"
 0:09:00 "<NULL-object>"
 0:09:00 "<NULL-object>"
 0:09:00 "<NULL-object>"
 0:09:00 "<NULL-object>"
 0:09:00 "<NULL-object>"
 0:09:00 "<NULL-object>"
 0:09:00 "<NULL-object>"
 0:09:01 "<NULL-object>"
 0:09:01 "<NULL-object>"
 0:09:01 "<NULL-object>"
```

Only sensible thing we can do is exit out when anything `nuill` is passed to the garbage cleaner, will need to keep an eye on the number mid-mission and make sure everything still cleans up properly!