### PR TITLE
Remove BIS_noCoreConversations

### DIFF
--- a/hull3/hull3.h
+++ b/hull3/hull3.h
@@ -369,7 +369,7 @@ class Hull3 {
     };
 
     class General {
-        BIS_noCoreConversations = 1;                    // Disables BIS unit conversations
+        radioProtocol = 0;                              // Use disableAI to stop units talking
         enableSaving = 0;                               // Enables game saving
         disableRemoteSensors = 1;                       // Disables RemoteSensors
         enableEnvironment = 0;                          // Disables ambient animals but keeps sounds

--- a/hull3/settings_functions.sqf
+++ b/hull3/settings_functions.sqf
@@ -34,8 +34,10 @@ hull3_settings_fnc_setNonStandardGeneralSettings = {
 };
 
 hull3_settings_fnc_setPlayerSettings = {
-    player setVariable ["BIS_noCoreConversations", ["General", "BIS_noCoreConversations"] call hull3_config_fnc_getBool];
-    DEBUG("hull3.settings",FMT_1("Player variable 'BIS_noCoreConversations' is set to '%1'.",AS_ARRAY_2("General", "BIS_noCoreConversations") call hull3_config_fnc_getBool));
+    if (!(["General", "radioProtocol"] call hull3_config_fnc_getBool)) then {
+        player disableAI "RADIOPROTOCOL";
+        DEBUG("hull3.settings","RADIOPROTOCOL is disabled");
+    };
 };
 
 hull3_settings_fnc_setModuleVariables = {

--- a/hull3/unit_functions.sqf
+++ b/hull3/unit_functions.sqf
@@ -50,6 +50,7 @@ hull3_unit_fnc_foreachNonPlayerUnits = {
     {
         if (!isPlayer _x) then {
             doStop _x;
+            _x disableAI "RADIOPROTOCOL";
         };
     } foreach (playableUnits + switchableUnits);
 };


### PR DESCRIPTION
Switch to use `disableAI` for RadioProtocols, according to the wiki it should "Stops AI from talking and texting while still being able to issue orders."

Needs testing to make sure it doesn't do anything weird

- [ ] SP Editor
- [ ] MP Editor
- [ ] Dedi