### PR TITLE
Removing ghost in the shell

### DIFF
--- a/hull3/hull3.h
+++ b/hull3/hull3.h
@@ -369,8 +369,9 @@ class Hull3 {
     };
 
     class General {
-        BIS_noCoreConversations = 1;                    // Disables BIS unit conversations
+        enableRadio = 0;                                // Enables AI radio callouts being seen
         enableSaving = 0;                               // Enables game saving
+        enableSentences = 0;                            // Enables AI radio callouts being heard
         disableRemoteSensors = 1;                       // Disables RemoteSensors
         enableEnvironment = 0;                          // Disables ambient animals but keeps sounds
     };

--- a/hull3/hull3_preinit.sqf
+++ b/hull3/hull3_preinit.sqf
@@ -28,7 +28,6 @@ if (hull3_isEnabled) then {
     ["hull3.initialized", []] call hull3_event_fnc_emitEvent;
     INFO("hull3",FMT_1("Hull version '%1' has been successfully initialized.",HULL3_VERSION));
 
-    [] call hull3_settings_fnc_preInit;
     [] call hull3_mission_fnc_preInit;
     [] call hull3_marker_fnc_preInit;
     [] call hull3_gear_fnc_preInit;

--- a/hull3/settings_functions.sqf
+++ b/hull3/settings_functions.sqf
@@ -4,24 +4,23 @@
 #include "logbook.h"
 
 
-hull3_settings_fnc_preInit = {
-    [] call hull3_settings_fnc_addEventHandlers;
-    DEBUG("hull3.settings","Settings functions preInit finished.");
-};
-
 hull3_settings_fnc_init = {
     [] call hull3_settings_fnc_setNonStandardGeneralSettings;
     [] call hull3_settings_fnc_setModuleVariables;
 };
 
-hull3_settings_fnc_addEventHandlers = {
-    ["player.initialized", hull3_settings_fnc_setPlayerSettings] call hull3_event_fnc_addEventHandler;
-};
-
 hull3_settings_fnc_setNonStandardGeneralSettings = {
+    if (!(["General", "enableRadio"] call hull3_config_fnc_getBool)) then {
+        enableRadio false;
+        DEBUG("hull3.settings","enableRadio is disabled.");
+    };
     if (!(["General", "enableSaving"] call hull3_config_fnc_getBool)) then {
         enableSaving [false, false];
         DEBUG("hull3.settings","Saving is disabled.");
+    };
+    if (!(["General", "enableSentences"] call hull3_config_fnc_getBool)) then {
+        enableSentences false;
+        DEBUG("hull3.settings","enableSentences is disabled.");
     };
     if (["General", "disableRemoteSensors"] call hull3_config_fnc_getBool) then {
         disableRemoteSensors true;
@@ -31,11 +30,6 @@ hull3_settings_fnc_setNonStandardGeneralSettings = {
         [{time > 0}, {enableEnvironment [false, true];}] call CBA_fnc_waitUntilAndExecute;
         DEBUG("hull3.settings","Ambient animals are disabled.");
     };
-};
-
-hull3_settings_fnc_setPlayerSettings = {
-    player setVariable ["BIS_noCoreConversations", ["General", "BIS_noCoreConversations"] call hull3_config_fnc_getBool];
-    DEBUG("hull3.settings",FMT_1("Player variable 'BIS_noCoreConversations' is set to '%1'.",AS_ARRAY_2("General", "BIS_noCoreConversations") call hull3_config_fnc_getBool));
 };
 
 hull3_settings_fnc_setModuleVariables = {

--- a/hull3/settings_functions.sqf
+++ b/hull3/settings_functions.sqf
@@ -12,6 +12,7 @@ hull3_settings_fnc_init = {
 hull3_settings_fnc_setNonStandardGeneralSettings = {
     if (!(["General", "enableRadio"] call hull3_config_fnc_getBool)) then {
         enableRadio false;
+        0 fadeRadio 0;
         DEBUG("hull3.settings","enableRadio is disabled.");
     };
     if (!(["General", "enableSaving"] call hull3_config_fnc_getBool)) then {


### PR DESCRIPTION
Kills off `BIS_noCoreConversations` which is legacy and stopped working a while ago.

It also removes all preInit calls for settings, since all of them are now postInit only. Not sure if this is removing too much? @kami- 