### PR TITLE
Move logging/alerts to systemChat

### DIFF
--- a/hull3/acre_functions.sqf
+++ b/hull3/acre_functions.sqf
@@ -264,7 +264,7 @@ hull3_acre_fnc_adminAssignRadio = {
 
     if (player canAddItemToUniform _radio) then {
         player addItemToUniform _radio;
-        player globalChat format ["Requested radio '%1' has been added to uniform.", _radio];
+        systemChat format ["[Hull3] Requested radio '%1' has been added to uniform.", _radio];
         [[player, name player, _radio], {
             params ["_unit", "_name", "_radio"];
 
@@ -272,6 +272,6 @@ hull3_acre_fnc_adminAssignRadio = {
             diag_log LOGGING_FORMAT("hull3.acre.admin","WARN",_message);
         }] remoteExec ["bis_fnc_call", 2];
     } else {
-        player globalChat format ["Requested radio '%1' cannot be added to uniform. Make sure you have enough space!", _radio];
+        systemChat format ["[Hull3] Requested radio '%1' cannot be added to uniform. Make sure you have enough space!", _radio];
     };
 };

--- a/hull3/logbook.h
+++ b/hull3/logbook.h
@@ -48,7 +48,7 @@
 
 #define LB_CHAT_LOGGER(MESSG)
 #ifdef LOGGING_TO_CHAT
-    #define LB_CHAT_LOGGER(MESSG)               player globalChat (MESSG)
+    #define LB_CHAT_LOGGER(MESSG)               systemChat (MESSG)
 #endif //LOGGING_TO_CHAT
 
 #ifndef LOGGING_TO_CUSTOM

--- a/hull3/mission_functions.sqf
+++ b/hull3/mission_functions.sqf
@@ -246,7 +246,7 @@ hull3_mission_fnc_handleSafetyTimeChange = {
         };
     };
     if (_message != "") then {
-        player globalChat format [_message, _timeValue];
+        systemChat format ["[Hull3] " + _message, _timeValue];
     };
 };
 


### PR DESCRIPTION
Since merging of PR https://github.com/kami-/hull3/pull/377 apparently `enableRadio` also stops the use speaking through the AI via script, e.g. `player sideChat "test"`. However `systemChat` doesn't care about the unit so still functions.

I personally think this looks a bit cleaner anway.

Mission safety off:
![safety](https://user-images.githubusercontent.com/7225500/121808065-d64fc700-cc4e-11eb-89bf-389427227167.png)

Logbook on trace:
![logbook](https://user-images.githubusercontent.com/7225500/121808073-dbad1180-cc4e-11eb-83d3-cd334b9e42c8.png)

Will require PRs for Admiral for logbook too!