### PR TITLE
Remove fadeRadio

### DIFF
--- a/hull3/settings_functions.sqf
+++ b/hull3/settings_functions.sqf
@@ -12,7 +12,6 @@ hull3_settings_fnc_init = {
 hull3_settings_fnc_setNonStandardGeneralSettings = {
     if (!(["General", "enableRadio"] call hull3_config_fnc_getBool)) then {
         enableRadio false;
-        0 fadeRadio 0;
         DEBUG("hull3.settings","enableRadio is disabled.");
     };
     if (!(["General", "enableSaving"] call hull3_config_fnc_getBool)) then {


### PR DESCRIPTION
Some locking sounds and radar warnings play via the 'Radio' channel. With `enableRadio false` these still work but adding `fadeRadio` mutes them toally. Hopefully it doesn't make AI/units more talky...