### PR TITLE
Add support for insignias

### DIFF
--- a/hull3/assign/uniform/AAF_WD.h
+++ b/hull3/assign/uniform/AAF_WD.h
@@ -5,6 +5,7 @@ class AAF_WD {
         uniform = "U_I_CombatUniform";
         vest = "V_PlateCarrierIA2_dgtl_ARM";
         backpack = "B_Kitbag_rgr";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class AAF_WD {
     class Medic : Rifleman {
         backpack = "B_Carryall_oli";
         uniform = "U_I_CombatUniform_shortsleeve";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/AUS_AMCU.h
+++ b/hull3/assign/uniform/AUS_AMCU.h
@@ -5,6 +5,7 @@ class AUS_AMCU {
         uniform = "MNP_CombatUniform_AMCU_T";
         vest = "MNP_Vest_AMCU_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class AUS_AMCU {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         uniform = "MNP_CombatUniform_AMCU_ST";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/AUS_WD.h
+++ b/hull3/assign/uniform/AUS_WD.h
@@ -5,6 +5,7 @@ class AUS_WD {
         uniform = "MNP_CombatUniform_Australia";
         vest = "MNP_Vest_Australia_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class AUS_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/BAF_CBRN.h
+++ b/hull3/assign/uniform/BAF_CBRN.h
@@ -5,6 +5,7 @@ class BAF_CBRN {
         uniform = "U_B_CBRN_Suit_01_Wdl_F";
         vest = "CUP_V_B_BAF_MTP_Osprey_Mk4_Rifleman_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class BAF_CBRN {
         headGear = "CUP_H_BAF_MTP_Mk6_GOGGLES_PRR";
         vest = "CUP_V_B_BAF_MTP_Osprey_Mk4_Medic_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CAN_DE.h
+++ b/hull3/assign/uniform/CAN_DE.h
@@ -5,6 +5,7 @@ class CAN_DE {
         uniform = "MNP_CombatUniform_Canada_D";
         vest = "MNP_Vest_Canada_D2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CAN_DE {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CAN_WD.h
+++ b/hull3/assign/uniform/CAN_WD.h
@@ -5,6 +5,8 @@ class CAN_WD {
         uniform = "MNP_CombatUniform_Canada";
         vest = "MNP_Vest_Canada_T2_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +37,7 @@ class CAN_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CAN_WD.h
+++ b/hull3/assign/uniform/CAN_WD.h
@@ -5,7 +5,6 @@ class CAN_WD {
         uniform = "MNP_CombatUniform_Canada";
         vest = "MNP_Vest_Canada_T2_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CHKDZ.h
+++ b/hull3/assign/uniform/CHKDZ.h
@@ -5,6 +5,7 @@ class CHKDZ {
         uniform = "CUP_U_O_CHDKZ_Kam_01";
         vest = "CUP_V_RUS_Smersh_New_Buttpack_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -43,6 +44,7 @@ class CHKDZ {
         goggles = "";
         headGear = "CUP_H_ChDKZ_Beanie";
         uniform = "CUP_U_O_CHDKZ_Kam_03";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CN_DE.h
+++ b/hull3/assign/uniform/CN_DE.h
@@ -5,6 +5,7 @@ class CN_DE {
         uniform = "MNP_CombatUniform_China_D";
         vest = "MNP_Vest_ChinaH_D2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -32,6 +33,7 @@ class CN_DE {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CN_MAR.h
+++ b/hull3/assign/uniform/CN_MAR.h
@@ -5,6 +5,8 @@ class CN_MAR {
         uniform = "MNP_CombatUniform_CMAR";
         vest = "MNP_Vest_ChinaH_T2_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -32,6 +34,7 @@ class CN_MAR {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CN_MAR.h
+++ b/hull3/assign/uniform/CN_MAR.h
@@ -5,7 +5,6 @@ class CN_MAR {
         uniform = "MNP_CombatUniform_CMAR";
         vest = "MNP_Vest_ChinaH_T2_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CN_WD.h
+++ b/hull3/assign/uniform/CN_WD.h
@@ -5,6 +5,8 @@ class CN_WD {
         uniform = "MNP_CombatUniform_China";
         vest = "MNP_Vest_ChinaH_T2_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -32,6 +34,7 @@ class CN_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CN_WD.h
+++ b/hull3/assign/uniform/CN_WD.h
@@ -5,7 +5,6 @@ class CN_WD {
         uniform = "MNP_CombatUniform_China";
         vest = "MNP_Vest_ChinaH_T2_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CN_WD2.h
+++ b/hull3/assign/uniform/CN_WD2.h
@@ -5,6 +5,8 @@ class CN_WD2 {
         uniform = "MNP_CombatUniform_China_J";
         vest = "MNP_Vest_ChinaH_J2_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -31,6 +33,7 @@ class CN_WD2 {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CN_WD2.h
+++ b/hull3/assign/uniform/CN_WD2.h
@@ -5,7 +5,6 @@ class CN_WD2 {
         uniform = "MNP_CombatUniform_China_J";
         vest = "MNP_Vest_ChinaH_J2_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CSAT_SN.h
+++ b/hull3/assign/uniform/CSAT_SN.h
@@ -5,6 +5,7 @@ class CSAT_SN {
         uniform = "MNP_CombatUniform_Russia_arctic";
         vest = "V_PlateCarrier1_blk_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -31,6 +32,7 @@ class CSAT_SN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_BAF_DE.h
+++ b/hull3/assign/uniform/CUP_BAF_DE.h
@@ -5,6 +5,8 @@ class CUP_BAF_DE {
         uniform = "CUP_U_B_BAF_DDPM_S2_UnRolled";
         vest = "CUP_V_B_BAF_DDPM_Osprey_Mk3_Rifleman_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +43,7 @@ class CUP_BAF_DE {
         uniform = "CUP_U_B_BAF_DDPM_S2_UnRolled";
         vest = "CUP_V_B_BAF_DDPM_Osprey_Mk3_Medic_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_BAF_DE.h
+++ b/hull3/assign/uniform/CUP_BAF_DE.h
@@ -5,7 +5,6 @@ class CUP_BAF_DE {
         uniform = "CUP_U_B_BAF_DDPM_S2_UnRolled";
         vest = "CUP_V_B_BAF_DDPM_Osprey_Mk3_Rifleman_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_BAF_MTP.h
+++ b/hull3/assign/uniform/CUP_BAF_MTP.h
@@ -5,6 +5,8 @@ class CUP_BAF_MTP {
         uniform = "CUP_U_B_BAF_MTP_S4_UnRolled";
         vest = "CUP_V_B_BAF_MTP_Osprey_Mk4_Rifleman_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +43,7 @@ class CUP_BAF_MTP {
         uniform = "CUP_U_B_BAF_MTP_S4_UnRolled";
         vest = "CUP_V_B_BAF_MTP_Osprey_Mk4_Medic_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_BAF_MTP.h
+++ b/hull3/assign/uniform/CUP_BAF_MTP.h
@@ -5,7 +5,6 @@ class CUP_BAF_MTP {
         uniform = "CUP_U_B_BAF_MTP_S4_UnRolled";
         vest = "CUP_V_B_BAF_MTP_Osprey_Mk4_Rifleman_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_BAF_WD.h
+++ b/hull3/assign/uniform/CUP_BAF_WD.h
@@ -5,7 +5,6 @@ class CUP_BAF_WD {
         uniform = "CUP_U_B_BAF_DPM_S2_UnRolled";
         vest = "CUP_V_B_BAF_DPM_Osprey_Mk3_Rifleman_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_BAF_WD.h
+++ b/hull3/assign/uniform/CUP_BAF_WD.h
@@ -5,6 +5,8 @@ class CUP_BAF_WD {
         uniform = "CUP_U_B_BAF_DPM_S2_UnRolled";
         vest = "CUP_V_B_BAF_DPM_Osprey_Mk3_Rifleman_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +43,7 @@ class CUP_BAF_WD {
         uniform = "CUP_U_B_BAF_DPM_S2_UnRolled";
         vest = "CUP_V_B_BAF_DPM_Osprey_Mk3_Medic_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_DES.h
+++ b/hull3/assign/uniform/CUP_CDF_DES.h
@@ -5,7 +5,6 @@ class CUP_CDF_DES {
         uniform = "CUP_U_B_CDF_DST_1";
         vest = "CUP_V_CDF_6B3_1_DST_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_CDF_DES.h
+++ b/hull3/assign/uniform/CUP_CDF_DES.h
@@ -5,6 +5,8 @@ class CUP_CDF_DES {
         uniform = "CUP_U_B_CDF_DST_1";
         vest = "CUP_V_CDF_6B3_1_DST_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +36,7 @@ class CUP_CDF_DES {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_DES_UN.h
+++ b/hull3/assign/uniform/CUP_CDF_DES_UN.h
@@ -5,6 +5,8 @@ class CUP_CDF_DES_UN {
         uniform = "CUP_U_B_CDF_DST_1";
         vest = "CUP_V_CDF_6B3_1_DST_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +35,7 @@ class CUP_CDF_DES_UN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_DES_UN.h
+++ b/hull3/assign/uniform/CUP_CDF_DES_UN.h
@@ -5,7 +5,6 @@ class CUP_CDF_DES_UN {
         uniform = "CUP_U_B_CDF_DST_1";
         vest = "CUP_V_CDF_6B3_1_DST_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_CDF_FOR.h
+++ b/hull3/assign/uniform/CUP_CDF_FOR.h
@@ -5,7 +5,6 @@ class CUP_CDF_FOR {
         uniform = "CUP_U_B_CDF_FST_1";
         vest = "CUP_V_CDF_6B3_1_FST_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_CDF_FOR.h
+++ b/hull3/assign/uniform/CUP_CDF_FOR.h
@@ -5,6 +5,8 @@ class CUP_CDF_FOR {
         uniform = "CUP_U_B_CDF_FST_1";
         vest = "CUP_V_CDF_6B3_1_FST_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +36,7 @@ class CUP_CDF_FOR {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_FOR_UN.h
+++ b/hull3/assign/uniform/CUP_CDF_FOR_UN.h
@@ -5,7 +5,6 @@ class CUP_CDF_FOR_UN {
         uniform = "CUP_U_B_CDF_FST_1";
         vest = "CUP_V_CDF_6B3_1_FST_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_CDF_FOR_UN.h
+++ b/hull3/assign/uniform/CUP_CDF_FOR_UN.h
@@ -5,6 +5,8 @@ class CUP_CDF_FOR_UN {
         uniform = "CUP_U_B_CDF_FST_1";
         vest = "CUP_V_CDF_6B3_1_FST_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +35,7 @@ class CUP_CDF_FOR_UN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_MOU.h
+++ b/hull3/assign/uniform/CUP_CDF_MOU.h
@@ -5,6 +5,8 @@ class CUP_CDF_MOU {
         uniform = "CUP_U_B_CDF_MNT_1";
         vest = "CUP_V_CDF_6B3_1_MNT_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +36,7 @@ class CUP_CDF_MOU {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_MOU.h
+++ b/hull3/assign/uniform/CUP_CDF_MOU.h
@@ -5,7 +5,6 @@ class CUP_CDF_MOU {
         uniform = "CUP_U_B_CDF_MNT_1";
         vest = "CUP_V_CDF_6B3_1_MNT_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_CDF_MOU_UN.h
+++ b/hull3/assign/uniform/CUP_CDF_MOU_UN.h
@@ -5,6 +5,8 @@ class CUP_CDF_MOU_UN {
         uniform = "CUP_U_B_CDF_MNT_1";
         vest = "CUP_V_CDF_6B3_1_MNT_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +35,7 @@ class CUP_CDF_MOU_UN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_MOU_UN.h
+++ b/hull3/assign/uniform/CUP_CDF_MOU_UN.h
@@ -5,7 +5,6 @@ class CUP_CDF_MOU_UN {
         uniform = "CUP_U_B_CDF_MNT_1";
         vest = "CUP_V_CDF_6B3_1_MNT_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_CDF_SN.h
+++ b/hull3/assign/uniform/CUP_CDF_SN.h
@@ -5,6 +5,7 @@ class CUP_CDF_SN {
         uniform = "CUP_U_B_CDF_SNW_2";
         vest = "CUP_V_CDF_6B3_1_SNW_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class CUP_CDF_SN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_SN_UN.h
+++ b/hull3/assign/uniform/CUP_CDF_SN_UN.h
@@ -5,6 +5,8 @@ class CUP_CDF_SN_UN {
         uniform = "CUP_U_B_CDF_SNW_2";
         vest = "CUP_V_CDF_6B3_1_SNW_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +35,7 @@ class CUP_CDF_SN_UN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CDF_SN_UN.h
+++ b/hull3/assign/uniform/CUP_CDF_SN_UN.h
@@ -5,7 +5,6 @@ class CUP_CDF_SN_UN {
         uniform = "CUP_U_B_CDF_SNW_2";
         vest = "CUP_V_CDF_6B3_1_SNW_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_CZ_DE.h
+++ b/hull3/assign/uniform/CUP_CZ_DE.h
@@ -5,6 +5,7 @@ class CUP_CZ_DE {
         uniform = "CUP_U_B_CZ_DST_NoKneepads";
         vest = "CUP_V_CZ_NPP2006_nk_des_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class CUP_CZ_DE {
         headGear = "CUP_H_CZ_Helmet02";
         vest = "CUP_V_CZ_NPP2006_ok_des_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_CZ_WD.h
+++ b/hull3/assign/uniform/CUP_CZ_WD.h
@@ -5,6 +5,7 @@ class CUP_CZ_WD {
         uniform = "CUP_U_B_CZ_WDL_NoKneepads";
         vest = "CUP_V_CZ_NPP2006_nk_vz95_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class CUP_CZ_WD {
         headGear = "CUP_H_CZ_Helmet04";
         vest = "CUP_V_CZ_NPP2006_ok_vz95_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_GER_DE.h
+++ b/hull3/assign/uniform/CUP_GER_DE.h
@@ -5,7 +5,6 @@ class CUP_GER_DE {
         uniform = "CUP_U_B_GER_Tropentarn_5";
         vest = "CUP_V_B_GER_PVest_Trop_RFL_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_GER_DE.h
+++ b/hull3/assign/uniform/CUP_GER_DE.h
@@ -5,6 +5,8 @@ class CUP_GER_DE {
         uniform = "CUP_U_B_GER_Tropentarn_5";
         vest = "CUP_V_B_GER_PVest_Trop_RFL_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +41,7 @@ class CUP_GER_DE {
         uniform = "CUP_U_B_GER_Tropentarn_3";
         vest = "CUP_V_B_GER_PVest_Trop_Med_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_GER_WD.h
+++ b/hull3/assign/uniform/CUP_GER_WD.h
@@ -5,7 +5,6 @@ class CUP_GER_WD {
         uniform = "CUP_U_B_GER_Flecktarn_5";
         vest = "CUP_V_B_GER_PVest_Fleck_RFL_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_GER_WD.h
+++ b/hull3/assign/uniform/CUP_GER_WD.h
@@ -5,6 +5,8 @@ class CUP_GER_WD {
         uniform = "CUP_U_B_GER_Flecktarn_5";
         vest = "CUP_V_B_GER_PVest_Fleck_RFL_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +41,7 @@ class CUP_GER_WD {
         uniform = "CUP_U_B_GER_Flecktarn_3";
         vest = "CUP_V_B_GER_PVest_Fleck_Med_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_HIL_CCE.h
+++ b/hull3/assign/uniform/CUP_HIL_CCE.h
@@ -5,6 +5,7 @@ class CUP_HIL_CCE {
         uniform = "CUP_U_B_HIL_ACU_CCE";
         vest = "CUP_V_PMC_CIRAS_OD_Patrol_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class CUP_HIL_CCE {
         headGear = "CUP_H_HIL_HelmetACH_GCovered_CCE";
         uniform = "CUP_U_B_HIL_ACU_Kneepad_Rolled_CCE";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_HIL_RES.h
+++ b/hull3/assign/uniform/CUP_HIL_RES.h
@@ -5,6 +5,7 @@ class CUP_HIL_RES {
         uniform = "CUP_U_B_BDUv2_OD";
         vest = "CUP_V_B_PASGT_CCE_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class CUP_HIL_RES {
         headGear = "CUP_H_Ger_M92_RGR_GG_CB";
         uniform = "CUP_U_B_BDUv2_roll_gloves_OD";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_HIL_TTS.h
+++ b/hull3/assign/uniform/CUP_HIL_TTS.h
@@ -5,6 +5,7 @@ class CUP_HIL_TTS {
         uniform = "CUP_U_B_HIL_ACU_TTS";
         vest = "CUP_V_CPC_Fastbelt_rngr_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -42,6 +43,7 @@ class CUP_HIL_TTS {
         uniform = "CUP_U_B_HIL_ACU_Kneepad_Rolled_TTS";
         vest = "CUP_V_CPC_medicalbelt_rngr_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_ION_PMC.h
+++ b/hull3/assign/uniform/CUP_ION_PMC.h
@@ -5,6 +5,8 @@ class CUP_ION_PMC {
         uniform = "CUP_I_B_PMC_Unit_6";
         vest = "CUP_V_PMC_CIRAS_Coyote_Patrol_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +39,7 @@ class CUP_ION_PMC {
         backpack = "ark_backpack_large";
         uniform = "CUP_I_B_PMC_Unit_19";
         headGear = "CUP_H_USArmy_Helmet_ECH1_Sand";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_ION_PMC.h
+++ b/hull3/assign/uniform/CUP_ION_PMC.h
@@ -5,7 +5,6 @@ class CUP_ION_PMC {
         uniform = "CUP_I_B_PMC_Unit_6";
         vest = "CUP_V_PMC_CIRAS_Coyote_Patrol_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_ION_PMC_SN.h
+++ b/hull3/assign/uniform/CUP_ION_PMC_SN.h
@@ -5,6 +5,7 @@ class CUP_ION_PMC_SN {
         uniform = "CUP_I_B_PMC_Unit_27";
         vest = "CUP_V_PMC_CIRAS_Winter_Patrol_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class CUP_ION_PMC_SN {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         headGear = "CUP_H_USArmy_Helmet_ECH1_Black";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_KSK_DE.h
+++ b/hull3/assign/uniform/CUP_KSK_DE.h
@@ -5,6 +5,7 @@ class CUP_KSK_DE {
         uniform = "CUP_U_B_GER_Crye";
         vest = "CUP_V_B_GER_Carrier_Vest_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class CUP_KSK_DE {
     class Medic : Rifleman {
         vest = "CUP_V_B_GER_Armatus_Trop_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_KSK_WD.h
+++ b/hull3/assign/uniform/CUP_KSK_WD.h
@@ -5,6 +5,8 @@ class CUP_KSK_WD {
         uniform = "CUP_U_B_GER_Fleck_Crye";
         vest = "CUP_V_B_GER_Carrier_Vest_ARM";
         backpack = "ark_backpack_med";
+    insignia = "";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +39,7 @@ class CUP_KSK_WD {
     class Medic : Rifleman {
         vest = "CUP_V_B_GER_Armatus_Fleck_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_KSK_WD.h
+++ b/hull3/assign/uniform/CUP_KSK_WD.h
@@ -5,7 +5,6 @@ class CUP_KSK_WD {
         uniform = "CUP_U_B_GER_Fleck_Crye";
         vest = "CUP_V_B_GER_Carrier_Vest_ARM";
         backpack = "ark_backpack_med";
-    insignia = "";
         insignia = "";
     };
 

--- a/hull3/assign/uniform/CUP_NAPA_WD.h
+++ b/hull3/assign/uniform/CUP_NAPA_WD.h
@@ -5,6 +5,7 @@ class CUP_NAPA_WD {
         uniform = "CUP_U_I_GUE_Flecktarn2";
         vest = "CUP_V_B_GER_Carrier_Rig_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -44,6 +45,7 @@ class CUP_NAPA_WD {
         backpack = "ark_backpack_large";
         goggles = "";
         headGear = "H_Bandanna_khk_hs";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RACS_DE.h
+++ b/hull3/assign/uniform/CUP_RACS_DE.h
@@ -5,6 +5,7 @@ class CUP_RACS_DE {
         uniform = "CUP_U_I_RACS_Desert_1";
         vest = "CUP_V_B_Interceptor_Rifleman_Coyote_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_RACS_DE {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RACS_MECH.h
+++ b/hull3/assign/uniform/CUP_RACS_MECH.h
@@ -5,6 +5,7 @@ class CUP_RACS_MECH {
         uniform = "CUP_U_I_RACS_mech_1";
         vest = "CUP_V_B_Interceptor_Rifleman_Olive_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class CUP_RACS_MECH {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RACS_URB.h
+++ b/hull3/assign/uniform/CUP_RACS_URB.h
@@ -5,6 +5,7 @@ class CUP_RACS_URB {
         uniform = "CUP_U_I_RACS_Urban_1";
         vest = "CUP_V_B_Interceptor_Rifleman_Grey_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_RACS_URB {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RU_90_DE.h
+++ b/hull3/assign/uniform/CUP_RU_90_DE.h
@@ -5,6 +5,7 @@ class CUP_RU_90_DE {
         uniform = "CUP_U_O_RUS_M88_VDV";
         vest = "CUP_V_RUS_Smersh_New_Buttpack_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class CUP_RU_90_DE {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RU_90_WD.h
+++ b/hull3/assign/uniform/CUP_RU_90_WD.h
@@ -5,6 +5,7 @@ class CUP_RU_90_WD {
         uniform = "CUP_U_O_RUS_VSR98_worn_MSV";
         vest = "CUP_V_RUS_6B3_Flora_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_RU_90_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RU_DE.h
+++ b/hull3/assign/uniform/CUP_RU_DE.h
@@ -5,6 +5,7 @@ class CUP_RU_DE {
         uniform = "CUP_U_O_RUS_BeigeDigital_MSV";
         vest = "CUP_V_RUS_6B45_1_BeigeDigital_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_RU_DE {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RU_MOD_DE.h
+++ b/hull3/assign/uniform/CUP_RU_MOD_DE.h
@@ -5,6 +5,7 @@ class CUP_RU_MOD_DE {
         uniform = "CUP_U_O_RUS_Soldier_VKPO_VDV_BeigeDigital_gloves_pads";
         vest = "CUP_Vest_RUS_6B45_Sh117_BeigeDigital_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class CUP_RU_MOD_DE {
     class Medic : Rifleman {
         headGear = "CUP_H_RUS_6B47_v2_GogglesClosed_BeigeDigital";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RU_MOD_PK.h
+++ b/hull3/assign/uniform/CUP_RU_MOD_PK.h
@@ -5,6 +5,7 @@ class CUP_RU_MOD_PK {
         uniform = "CUP_U_O_RUS_Soldier_VKPO_VDV_Pink_gloves_pads";
         vest = "CUP_Vest_RUS_6B45_Sh117_Desert_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class CUP_RU_MOD_PK {
     class Medic : Rifleman {
         headGear = "CUP_H_RUS_6B47_v2_GogglesClosed_Desert";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RU_MOD_SN.h
+++ b/hull3/assign/uniform/CUP_RU_MOD_SN.h
@@ -5,6 +5,7 @@ class CUP_RU_MOD_SN {
         uniform = "CUP_U_O_RUS_Ratnik_Winter";
         vest = "CUP_Vest_RUS_6B45_Sh117_Green_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_RU_MOD_SN {
     class Medic : Rifleman {
         headGear = "CUP_H_RUS_6B47_v2_GogglesClosed_Winter";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RU_MOD_WD.h
+++ b/hull3/assign/uniform/CUP_RU_MOD_WD.h
@@ -5,6 +5,7 @@ class CUP_RU_MOD_WD {
         uniform = "CUP_U_O_RUS_Soldier_VKPO_VDV_EMR_gloves_pads";
         vest = "CUP_Vest_RUS_6B45_Sh117_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class CUP_RU_MOD_WD {
     class Medic : Rifleman {
         headGear = "CUP_H_RUS_6B47_v2_GogglesClosed_Summer";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_RU_WD.h
+++ b/hull3/assign/uniform/CUP_RU_WD.h
@@ -5,6 +5,7 @@ class CUP_RU_WD {
         uniform = "CUP_U_O_RUS_EMR_1";
         vest = "CUP_V_RUS_6B45_1_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_RU_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_SLA_DE.h
+++ b/hull3/assign/uniform/CUP_SLA_DE.h
@@ -5,6 +5,7 @@ class CUP_SLA_DE {
         uniform = "CUP_U_O_SLA_Desert";
         vest = "CUP_V_O_SLA_6B3_1_DES_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_SLA_DE {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_SLA_MIL.h
+++ b/hull3/assign/uniform/CUP_SLA_MIL.h
@@ -5,6 +5,7 @@ class CUP_SLA_MIL {
         uniform = "CUP_U_O_SLA_Green";
         vest = "CUP_V_O_SLA_Carrier_Belt_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_SLA_MIL {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_SLA_PAR.h
+++ b/hull3/assign/uniform/CUP_SLA_PAR.h
@@ -5,6 +5,7 @@ class CUP_SLA_PAR {
         uniform = "CUP_U_O_Partisan_VSR_Mixed1";
         vest = "CUP_V_CDF_6B3_1_Green_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class CUP_SLA_PAR {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_SLA_URB.h
+++ b/hull3/assign/uniform/CUP_SLA_URB.h
@@ -5,6 +5,7 @@ class CUP_SLA_URB {
         uniform = "CUP_U_O_SLA_Urban";
         vest = "CUP_V_O_SLA_6B3_1_URB_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class CUP_SLA_URB {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_SLA_WD.h
+++ b/hull3/assign/uniform/CUP_SLA_WD.h
@@ -5,6 +5,7 @@ class CUP_SLA_WD {
         uniform = "CUP_U_O_SLA_MixedCamo";
         vest = "CUP_V_O_SLA_6B3_1_WDL_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class CUP_SLA_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_TKA_MIX.h
+++ b/hull3/assign/uniform/CUP_TKA_MIX.h
@@ -5,6 +5,7 @@ class CUP_TKA_MIX {
         uniform = "CUP_U_O_TK_MixedCamo";
         vest = "CUP_V_O_TK_Vest_1_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class CUP_TKA_MIX {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "CUP_V_O_TK_Vest_2_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_TKA_OD.h
+++ b/hull3/assign/uniform/CUP_TKA_OD.h
@@ -5,6 +5,7 @@ class CUP_TKA_OD {
         uniform = "CUP_U_O_TK_Green";
         vest = "CUP_V_O_TK_Vest_1_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class CUP_TKA_OD {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "CUP_V_O_TK_Vest_2_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_TK_INS.h
+++ b/hull3/assign/uniform/CUP_TK_INS.h
@@ -5,6 +5,7 @@ class CUP_TK_INS {
         uniform = "CUP_O_TKI_Khet_Partug_01";
         vest = "CUP_V_OI_TKI_Jacket4_02_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -47,6 +48,7 @@ class CUP_TK_INS {
         uniform = "CUP_O_TKI_Khet_Partug_05";
         headGear = "CUP_H_TKI_SkullCap_06";
         vest = "CUP_V_OI_TKI_Jacket3_03_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_TK_LOC.h
+++ b/hull3/assign/uniform/CUP_TK_LOC.h
@@ -5,6 +5,7 @@ class CUP_TK_LOC {
         uniform = "CUP_O_TKI_Khet_Jeans_04";
         vest = "CUP_V_OI_TKI_Jacket4_06_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -46,6 +47,7 @@ class CUP_TK_LOC {
         headGear = "CUP_H_TKI_SkullCap_06";
         vest = "CUP_V_OI_TKI_Jacket2_06_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_USA_OCP.h
+++ b/hull3/assign/uniform/CUP_USA_OCP.h
@@ -5,6 +5,7 @@ class CUP_USA_OCP {
         uniform = "CUP_U_B_USArmy_ACU_OCP";
         vest = "CUP_V_B_IOTV_OCP_Rifleman_USArmy_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class CUP_USA_OCP {
         uniform = "CUP_U_B_USArmy_ACU_Kneepad_OCP";
         vest = "CUP_V_B_IOTV_OCP_Medic_USArmy_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_USA_RAN.h
+++ b/hull3/assign/uniform/CUP_USA_RAN.h
@@ -5,6 +5,7 @@ class CUP_USA_RAN {
         uniform = "CUP_U_B_USArmy_ACU_OEFCP";
         vest = "CUP_V_B_IOTV_OEFCP_Rifleman_USArmy_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class CUP_USA_RAN {
         uniform = "CUP_U_B_USArmy_ACU_Kneepad_OEFCP";
         vest = "CUP_V_B_IOTV_OEFCP_Medic_USArmy_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_USA_RAN_UCP.h
+++ b/hull3/assign/uniform/CUP_USA_RAN_UCP.h
@@ -5,6 +5,7 @@ class CUP_USA_RAN_UCP {
         uniform = "CUP_U_B_USArmy_ACU_UCP";
         vest = "CUP_V_B_IOTV_UCP_Rifleman_USArmy_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class CUP_USA_RAN_UCP {
         uniform = "CUP_U_B_USArmy_ACU_Kneepad_UCP";
         vest = "CUP_V_B_IOTV_UCP_Medic_USArmy_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_USA_UCP.h
+++ b/hull3/assign/uniform/CUP_USA_UCP.h
@@ -5,6 +5,7 @@ class CUP_USA_UCP {
         uniform = "CUP_U_B_USArmy_ACU_UCP";
         vest = "CUP_V_B_IOTV_UCP_Rifleman_USArmy_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class CUP_USA_UCP {
         uniform = "CUP_U_B_USArmy_ACU_Kneepad_UCP";
         vest = "CUP_V_B_IOTV_UCP_Medic_USArmy_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_USMC_DE.h
+++ b/hull3/assign/uniform/CUP_USMC_DE.h
@@ -5,6 +5,7 @@ class CUP_USMC_DE {
         uniform = "CUP_U_B_USMC_MCCUU_des";
         vest = "CUP_V_B_Eagle_SPC_Patrol_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -42,6 +43,7 @@ class CUP_USMC_DE {
         uniform = "CUP_U_B_USMC_MCCUU_des_gloves";
         vest = "CUP_V_B_Eagle_SPC_Corpsman_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_USMC_MTV_DE.h
+++ b/hull3/assign/uniform/CUP_USMC_MTV_DE.h
@@ -5,6 +5,7 @@ class CUP_USMC_MTV_DE {
         uniform = "CUP_U_B_USMC_MCCUU_des";
         vest = "CUP_V_B_MTV_Patrol_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class CUP_USMC_MTV_DE {
         uniform = "CUP_U_B_USMC_MCCUU_des_gloves";
         vest = "CUP_V_B_MTV_Pouches_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_USMC_MTV_WD.h
+++ b/hull3/assign/uniform/CUP_USMC_MTV_WD.h
@@ -5,6 +5,7 @@ class CUP_USMC_MTV_WD {
         uniform = "CUP_U_B_USMC_MCCUU";
         vest = "CUP_V_B_MTV_Patrol_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class CUP_USMC_MTV_WD {
         uniform = "CUP_U_B_USMC_MCCUU_gloves";
         vest = "CUP_V_B_MTV_Pouches_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/CUP_USMC_WD.h
+++ b/hull3/assign/uniform/CUP_USMC_WD.h
@@ -5,6 +5,7 @@ class CUP_USMC_WD {
         uniform = "CUP_U_B_USMC_MCCUU";
         vest = "CUP_V_B_Eagle_SPC_Patrol_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -42,6 +43,7 @@ class CUP_USMC_WD {
         uniform = "CUP_U_B_USMC_MCCUU_gloves";
         vest = "CUP_V_B_Eagle_SPC_Corpsman_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/DPR_AUT.h
+++ b/hull3/assign/uniform/DPR_AUT.h
@@ -5,6 +5,7 @@ class DPR_AUT {
         uniform = "MNP_CombatUniform_DPR_A";
         vest = "CUP_V_RUS_Smersh_New_Buttpack_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class DPR_AUT {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         uniform = "MNP_CombatUniform_DPR_B";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/DPR_SUM.h
+++ b/hull3/assign/uniform/DPR_SUM.h
@@ -5,6 +5,7 @@ class DPR_SUM {
         uniform = "MNP_CombatUniform_DPR_B";
         vest = "CUP_V_RUS_Smersh_New_Buttpack_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class DPR_SUM {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         uniform = "MNP_CombatUniform_DPR_B";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FIA.h
+++ b/hull3/assign/uniform/FIA.h
@@ -5,6 +5,7 @@ class FIA {
         uniform = "U_BG_Guerilla1_1";
         vest = "V_PlateCarrier1_blk_ARM";
         backpack = "B_Kitbag_rgr";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class FIA {
         backpack = "B_Carryall_oli";
         uniform = "U_BG_Guerilla2_3";
         goggles = "";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FIN_SN.h
+++ b/hull3/assign/uniform/FIN_SN.h
@@ -5,6 +5,7 @@ class FIN_SN {
         uniform = "MNP_CombatUniform_Finarctic_A";
         vest = "MNP_Vest_FIN_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class FIN_SN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FIN_WD.h
+++ b/hull3/assign/uniform/FIN_WD.h
@@ -5,6 +5,7 @@ class FIN_WD {
         uniform = "MNP_CombatUniform_Fin_A";
         vest = "MNP_Vest_FIN_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class FIN_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_AUS_U.h
+++ b/hull3/assign/uniform/FOW_AUS_U.h
@@ -5,6 +5,7 @@ class FOW_AUS_U {
         uniform = "fow_u_aus_m37_02_private";
         vest = "fow_v_uk_base_green";
         backpack = "fow_b_uk_p37_blanco";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_AUS_U {
         backpack = "fow_b_uk_bergenpack";
         uniform = "fow_u_aus_m37_03_private";
         headGear = "fow_h_uk_mk2_net";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_BAF_COM_U.h
+++ b/hull3/assign/uniform/FOW_BAF_COM_U.h
@@ -5,6 +5,7 @@ class FOW_BAF_COM_U {
         uniform = "fow_u_uk_bd40_commando_01_private";
         vest = "fow_v_uk_para_base";
         backpack = "fow_b_uk_p37_blanco";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class FOW_BAF_COM_U {
         backpack = "fow_b_uk_bergenpack";
         uniform = "fow_u_uk_bd40_commando_01_private";
         headGear = "fow_h_uk_mk2_net_camo";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_BAF_ESX_U.h
+++ b/hull3/assign/uniform/FOW_BAF_ESX_U.h
@@ -5,6 +5,7 @@ class FOW_BAF_ESX_U {
         uniform = "fow_u_uk_bd40_01_private";
         vest = "fow_v_uk_base";
         backpack = "fow_b_uk_p37";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class FOW_BAF_ESX_U {
         backpack = "fow_b_uk_bergenpack";
         uniform = "fow_u_uk_bd40_corporal";
         headGear = "fow_h_uk_mk3_net_camo";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_BAF_PAC_U.h
+++ b/hull3/assign/uniform/FOW_BAF_PAC_U.h
@@ -5,6 +5,7 @@ class FOW_BAF_PAC_U {
         uniform = "fow_u_uk_bd40_seac_01_private";
         vest = "fow_v_uk_base_green";
         backpack = "fow_b_uk_p37_blanco";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class FOW_BAF_PAC_U {
         backpack = "fow_b_uk_bergenpack";
         uniform = "fow_u_uk_bd40_seac_02_corporal";
         headGear = "fow_h_uk_mk2_net";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_BAF_PARA_U.h
+++ b/hull3/assign/uniform/FOW_BAF_PARA_U.h
@@ -5,6 +5,7 @@ class FOW_BAF_PARA_U {
         uniform = "fow_u_uk_parasmock";
         vest = "fow_v_uk_para_base";
         backpack = "fow_b_uk_p37_blanco";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class FOW_BAF_PARA_U {
         backpack = "fow_b_uk_bergenpack";
         uniform = "fow_u_uk_parasmock";
         headGear = "fow_h_uk_mk2_para_camo";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_BAF_U.h
+++ b/hull3/assign/uniform/FOW_BAF_U.h
@@ -5,6 +5,7 @@ class FOW_BAF_U {
         uniform = "fow_u_uk_bd40_private";
         vest = "fow_v_uk_base";
         backpack = "fow_b_uk_p37";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class FOW_BAF_U {
         backpack = "fow_b_uk_bergenpack";
         uniform = "fow_u_uk_bd40_corporal";
         headGear = "fow_h_uk_mk2_net";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_CAN_U.h
+++ b/hull3/assign/uniform/FOW_CAN_U.h
@@ -5,6 +5,7 @@ class FOW_CAN {
         uniform = "fow_u_uk_bd40_can_01_private";
         vest = "fow_v_uk_base";
         backpack = "fow_b_uk_p37";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class FOW_CAN {
         backpack = "fow_b_uk_bergenpack";
         uniform = "fow_u_uk_bd40_can_01_corporal";
         headGear = "fow_h_uk_mk3_net_camo";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_GER_PARA_U.h
+++ b/hull3/assign/uniform/FOW_GER_PARA_U.h
@@ -5,6 +5,7 @@ class FOW_GER_PARA_U {
         uniform = "fow_u_ger_fall_03_private";
         vest = "fow_v_heer_k98_ARM";
         backpack = "fow_b_heer_aframe";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_GER_PARA_U {
         vest = "fow_v_heer_g43_ARM";
         uniform = "fow_u_ger_fall_03_lance_corporal";
         headGear = "fow_h_ger_m40_fall_01_camo";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_GER_SS_U.h
+++ b/hull3/assign/uniform/FOW_GER_SS_U.h
@@ -5,6 +5,7 @@ class FOW_GER_SS_U {
         uniform = "fow_u_ger_m43_peadot_01_private";
         vest = "fow_v_heer_k98_ARM";
         backpack = "fow_b_heer_aframe";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_GER_SS_U {
         vest = "fow_v_heer_g43_ARM";
         uniform = "fow_u_ger_m43_ss_01_private";
         headGear = "fow_h_ger_m40_ss_02";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_GER_U.h
+++ b/hull3/assign/uniform/FOW_GER_U.h
@@ -5,6 +5,7 @@ class FOW_GER_U {
         uniform = "fow_u_ger_m43_01_private";
         vest = "fow_v_heer_k98_ARM";
         backpack = "fow_b_heer_aframe";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_GER_U {
         vest = "fow_v_heer_g43_ARM";
         uniform = "fow_u_ger_m43_02_lance_corporal";
         headGear = "fow_h_ger_m40_heer_02";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_IJA_SNLF_U.h
+++ b/hull3/assign/uniform/FOW_IJA_SNLF_U.h
@@ -5,6 +5,7 @@ class FOW_IJA_SNLF_U {
         uniform = "fow_u_ija_type98_snlf";
         vest = "fow_v_ija_rifle_ARM";
         backpack = "fow_b_ija_backpack";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_IJA_SNLF_U {
         uniform = "fow_u_ija_type98_snlf";
         vest = "fow_v_ija_medic_ARM";
         headGear = "fow_h_ija_type90_snlf";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_IJA_U.h
+++ b/hull3/assign/uniform/FOW_IJA_U.h
@@ -5,6 +5,7 @@ class FOW_IJA_U {
         uniform = "fow_u_ija_type98";
         vest = "fow_v_ija_rifle_ARM";
         backpack = "fow_b_ija_backpack";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_IJA_U {
         uniform = "fow_u_ija_type98";
         vest = "fow_v_ija_medic_ARM";
         headGear = "fow_h_ija_type90_net_neck";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_USA_PAC_U.h
+++ b/hull3/assign/uniform/FOW_USA_PAC_U.h
@@ -5,6 +5,7 @@ class FOW_USA_PAC_U {
         uniform = "fow_u_us_hbt_01_private";
         vest = "fow_v_us_garand_ARM";
         backpack = "fow_b_us_m1928";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_USA_PAC_U {
         vest = "fow_v_us_carbine_ARM";
         backpack = "fow_b_us_m1944";
         uniform = "fow_u_us_hbt_02_private";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_USA_PARA_U.h
+++ b/hull3/assign/uniform/FOW_USA_PARA_U.h
@@ -5,6 +5,7 @@ class FOW_USA_PARA_U {
         uniform = "fow_u_us_m42_ab_01_101_private";
         vest = "fow_v_us_ab_garand_ARM";
         backpack = "fow_b_us_m1944";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_USA_PARA_U {
         vest = "fow_v_us_ab_carbine_ARM";
         backpack = "fow_b_us_m1944";
         uniform = "fow_u_us_m42_ab_01_101_private";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_USA_U.h
+++ b/hull3/assign/uniform/FOW_USA_U.h
@@ -5,6 +5,7 @@ class FOW_USA_U {
         uniform = "fow_u_us_m37_01_private";
         vest = "fow_v_us_garand_ARM";
         backpack = "fow_b_us_m1928";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class FOW_USA_U {
         vest = "fow_v_us_carbine_ARM";
         backpack = "fow_b_us_m1944";
         uniform = "fow_u_us_m37_02_private";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/FOW_USMC_U.h
+++ b/hull3/assign/uniform/FOW_USMC_U.h
@@ -5,6 +5,7 @@ class FOW_USMC_U {
         uniform = "fow_u_usmc_p42_01_camo01_1_private";
         vest = "fow_v_usmc_garand_ARM";
         backpack = "fow_b_usmc_m1928";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class FOW_USMC_U {
         vest = "fow_v_usmc_carbine_ARM";
         backpack = "fow_b_usmc_m1928_02";
         uniform = "fow_u_usmc_p42_01_camo01_3_private";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GEND_COP.h
+++ b/hull3/assign/uniform/GEND_COP.h
@@ -5,6 +5,7 @@ class GEND_COP {
         uniform = "U_B_GEN_Commander_F";
         vest = "V_TacVest_gen_F_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -30,6 +31,7 @@ class GEND_COP {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GEND_SWAT.h
+++ b/hull3/assign/uniform/GEND_SWAT.h
@@ -5,6 +5,7 @@ class GEND_SWAT {
         uniform = "U_B_GEN_Soldier_F";
         vest = "V_PlateCarrier1_blk_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -30,6 +31,7 @@ class GEND_SWAT {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_DNK_80_SN.h
+++ b/hull3/assign/uniform/GM_DNK_80_SN.h
@@ -5,6 +5,7 @@ class GM_DNK_80_SN {
         uniform = "gm_dk_army_uniform_soldier_84_win";
         vest = "gm_dk_army_vest_54_rifleman_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -32,6 +33,7 @@ class GM_DNK_80_SN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_DNK_80_WD.h
+++ b/hull3/assign/uniform/GM_DNK_80_WD.h
@@ -5,6 +5,7 @@ class GM_DNK_80_WD {
         uniform = "gm_dk_army_uniform_soldier_84_oli";
         vest = "gm_dk_army_vest_54_rifleman_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class GM_DNK_80_WD {
     class Medic : Rifleman {
         headGear = "gm_dk_headgear_m52_net_oli";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_DNK_90_SN.h
+++ b/hull3/assign/uniform/GM_DNK_90_SN.h
@@ -5,6 +5,7 @@ class GM_DNK_90_SN {
         uniform = "gm_dk_army_uniform_soldier_84_win";
         vest = "gm_dk_army_vest_m00_win_rifleman_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -32,6 +33,7 @@ class GM_DNK_90_SN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_DNK_90_WD.h
+++ b/hull3/assign/uniform/GM_DNK_90_WD.h
@@ -5,6 +5,7 @@ class GM_DNK_90_WD {
         uniform = "gm_dk_army_uniform_soldier_84_m84";
         vest = "gm_dk_army_vest_m00_m84_ARM_rifleman_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -32,6 +33,7 @@ class GM_DNK_90_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_FRG_80_AIR.h
+++ b/hull3/assign/uniform/GM_FRG_80_AIR.h
@@ -5,6 +5,7 @@ class GM_FRG_80_AIR {
         uniform = "gm_ge_army_uniform_soldier_80_oli";
         vest = "gm_ge_army_vest_80_rifleman_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class GM_FRG_80_AIR {
     class Medic : Rifleman {
         vest = "gm_ge_army_vest_80_medic_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_FRG_80_SN.h
+++ b/hull3/assign/uniform/GM_FRG_80_SN.h
@@ -5,6 +5,7 @@ class GM_FRG_80_SN {
         uniform = "gm_ge_army_uniform_soldier_parka_80_win";
         vest = "gm_ge_army_vest_80_rifleman_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class GM_FRG_80_SN {
     class Medic : Rifleman {
         vest = "gm_ge_army_vest_80_medic_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_FRG_80_WD.h
+++ b/hull3/assign/uniform/GM_FRG_80_WD.h
@@ -5,6 +5,7 @@ class GM_FRG_80_WD {
         uniform = "gm_ge_army_uniform_soldier_80_oli";
         vest = "gm_ge_army_vest_80_rifleman_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class GM_FRG_80_WD {
     class Medic : Rifleman {
         vest = "gm_ge_army_vest_80_medic_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_FRG_90_DE.h
+++ b/hull3/assign/uniform/GM_FRG_90_DE.h
@@ -5,6 +5,7 @@ class GM_FRG_90_DE {
         uniform = "gm_ge_uniform_soldier_90_trp";
         vest = "gm_ge_vest_90_rifleman_flk_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class GM_FRG_90_DE {
     class Medic : Rifleman {
         vest = "gm_ge_vest_90_medic_flk_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_FRG_90_SN.h
+++ b/hull3/assign/uniform/GM_FRG_90_SN.h
@@ -5,6 +5,7 @@ class GM_FRG_90_SN {
         uniform = "gm_ge_army_uniform_soldier_parka_80_win";
         vest = "gm_ge_vest_90_rifleman_flk_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class GM_FRG_90_SN {
     class Medic : Rifleman {
         vest = "gm_ge_vest_90_medic_flk_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_FRG_90_WD.h
+++ b/hull3/assign/uniform/GM_FRG_90_WD.h
@@ -5,6 +5,7 @@ class GM_FRG_90_WD {
         uniform = "gm_ge_uniform_soldier_90_flk";
         vest = "gm_ge_vest_90_rifleman_flk_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class GM_FRG_90_WD {
     class Medic : Rifleman {
         vest = "gm_ge_vest_90_medic_flk_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_FRG_BG.h
+++ b/hull3/assign/uniform/GM_FRG_BG.h
@@ -5,6 +5,7 @@ class GM_FRG_BG {
         uniform = "gm_ge_bgs_uniform_soldier_80_smp";
         vest = "gm_ge_bgs_vest_80_rifleman";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class GM_FRG_BG {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_GDR_80_AIR.h
+++ b/hull3/assign/uniform/GM_GDR_80_AIR.h
@@ -5,6 +5,7 @@ class GM_GDR_80_AIR {
         uniform = "gm_gc_army_uniform_soldier_80_str";
         vest = "gm_gc_army_vest_80_rifleman_str_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class GM_GDR_80_AIR {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_GDR_80_SN.h
+++ b/hull3/assign/uniform/GM_GDR_80_SN.h
@@ -5,6 +5,7 @@ class GM_GDR_80_SN {
         uniform = "gm_gc_army_uniform_soldier_80_win";
         vest = "gm_gc_army_vest_80_rifleman_str_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class GM_GDR_80_SN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_GDR_80_WD.h
+++ b/hull3/assign/uniform/GM_GDR_80_WD.h
@@ -5,6 +5,7 @@ class GM_GDR_80_WD {
         uniform = "gm_gc_army_uniform_soldier_80_str";
         vest = "gm_gc_army_vest_80_rifleman_str_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class GM_GDR_80_WD {
     class Medic : Rifleman {
         headGear = "gm_gc_army_headgear_m56_cover_str";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_GDR_BG.h
+++ b/hull3/assign/uniform/GM_GDR_BG.h
@@ -5,6 +5,7 @@ class GM_GDR_BG {
         uniform = "gm_gc_army_uniform_soldier_80_str";
         vest = "gm_gc_army_vest_80_rifleman_str_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class GM_GDR_BG {
     class Medic : Rifleman {
         headGear = "gm_gc_army_headgear_m56_cover_str";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_PRL_80_AIR.h
+++ b/hull3/assign/uniform/GM_PRL_80_AIR.h
@@ -5,6 +5,7 @@ class GM_PRL_80_AIR {
         uniform = "gm_pl_army_uniform_soldier_80_moro";
         vest = "gm_pl_army_vest_80_rifleman_gry_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class GM_PRL_80_AIR {
         uniform = "gm_pl_army_uniform_soldier_rolled_80_moro";
         vest = "gm_pl_army_vest_80_rifleman_smg_gry_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_PRL_80_SN.h
+++ b/hull3/assign/uniform/GM_PRL_80_SN.h
@@ -5,6 +5,7 @@ class GM_PRL_80_SN {
         uniform = "gm_pl_army_uniform_soldier_80_win";
         vest = "gm_pl_army_vest_80_rifleman_gry_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class GM_PRL_80_SN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/GM_PRL_80_WD.h
+++ b/hull3/assign/uniform/GM_PRL_80_WD.h
@@ -5,6 +5,7 @@ class GM_PRL_80_WD {
         uniform = "gm_pl_army_uniform_soldier_80_moro";
         vest = "gm_pl_army_vest_80_rifleman_gry_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class GM_PRL_80_WD {
         headGear = "gm_pl_army_headgear_wz67_net_oli";
         uniform = "gm_pl_army_uniform_soldier_rolled_80_moro";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IDF_10.h
+++ b/hull3/assign/uniform/IDF_10.h
@@ -5,6 +5,7 @@ class IDF_10 {
         uniform = "MNP_CombatUniform_ISR";
         vest = "MNP_Vest_ISRKahki_1_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class IDF_10 {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IDF_90.h
+++ b/hull3/assign/uniform/IDF_90.h
@@ -5,6 +5,7 @@ class IDF_90 {
         uniform = "MNP_CombatUniform_ISR";
         vest = "CUP_V_B_PASGT_OD_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class IDF_90 {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_BAF_NA_U.h
+++ b/hull3/assign/uniform/IF44_BAF_NA_U.h
@@ -5,6 +5,7 @@ class IF44_BAF_NA_U {
         uniform = "U_LIB_UK_KhakiDrills";
         vest = "V_LIB_UK_P37_Rifleman_ARM";
         backpack = "B_LIB_UK_HSack";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class IF44_BAF_NA_U {
     class Medic : Rifleman {
         backpack = "B_LIB_UK_HSack_Cape";
         headGear = "H_LIB_UK_Helmet_Mk2_Desert_Bowed";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_BAF_PARA_SN_U.h
+++ b/hull3/assign/uniform/IF44_BAF_PARA_SN_U.h
@@ -5,6 +5,7 @@ class IF44_BAF_PARA_SN_U {
         uniform = "U_LIB_UK_DenisonSmock_w";
         vest = "V_LIB_UK_P37_Rifleman_Blanco_ARM";
         backpack = "B_LIB_UK_HSack_Blanco";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class IF44_BAF_PARA_SN_U {
     class Medic : Rifleman {
         backpack = "B_LIB_UK_HSack_Blanco_Cape";
         headGear = "H_LIB_UK_Para_Helmet_Mk2_Net_w";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_BAF_PARA_U.h
+++ b/hull3/assign/uniform/IF44_BAF_PARA_U.h
@@ -5,6 +5,7 @@ class IF44_BAF_PARA_U {
         uniform = "U_LIB_UK_DenisonSmock";
         vest = "V_LIB_UK_P37_Rifleman_Blanco_ARM";
         backpack = "B_LIB_UK_HSack_Blanco";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class IF44_BAF_PARA_U {
     class Medic : Rifleman {
         backpack = "B_LIB_UK_HSack_Blanco_Cape";
         headGear = "H_LIB_UK_Para_Helmet_Mk2_Net";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_BAF_SN_U.h
+++ b/hull3/assign/uniform/IF44_BAF_SN_U.h
@@ -5,6 +5,7 @@ class IF44_BAF_SN_U {
         uniform = "U_LIB_UK_P37_w";
         vest = "V_LIB_UK_P37_Rifleman_Blanco_ARM";
         backpack = "B_LIB_UK_HSack_Blanco";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class IF44_BAF_SN_U {
     class Medic : Rifleman {
         backpack = "B_LIB_UK_HSack_Blanco_Cape";
         headGear = "H_LIB_UK_Helmet_Mk2_Net_w";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_BAF_U.h
+++ b/hull3/assign/uniform/IF44_BAF_U.h
@@ -5,6 +5,7 @@ class IF44_BAF_U {
         uniform = "U_LIB_UK_P37";
         vest = "V_LIB_UK_P37_Rifleman_Blanco_ARM";
         backpack = "B_LIB_UK_HSack_Blanco";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class IF44_BAF_U {
         backpack = "B_LIB_UK_HSack_Blanco_Cape";
         uniform = "U_LIB_UK_P37_LanceCorporal";
         headGear = "H_LIB_UK_Helmet_Mk2_Bowed";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_GER_NA_U.h
+++ b/hull3/assign/uniform/IF44_GER_NA_U.h
@@ -5,6 +5,7 @@ class IF44_GER_NA_U {
         uniform = "U_LIB_DAK_Shorts";
         vest = "V_LIB_DAK_VestKar98_ARM";
         backpack = "B_LIB_GER_Tonister34_cowhide";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class IF44_GER_NA_U {
         uniform = "U_LIB_DAK_Soldier";
         vest = "V_LIB_DAK_VestG43_ARM";
         headGear = "H_LIB_DAK_Helmet_net_2";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_GER_PARA_U.h
+++ b/hull3/assign/uniform/IF44_GER_PARA_U.h
@@ -5,6 +5,7 @@ class IF44_GER_PARA_U {
         uniform = "U_LIB_FSJ_Soldier";
         vest = "V_LIB_GER_FSJ_VestKar98_ARM";
         backpack = "B_LIB_GER_Tonister34_cowhide";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class IF44_GER_PARA_U {
         backpack = "B_LIB_GER_MedicBackpack_Empty";
         vest = "V_LIB_GER_VestG43_ARM";
         headGear = "H_LIB_GER_FSJ_M44_Helmet_Medic";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_GER_SN_U.h
+++ b/hull3/assign/uniform/IF44_GER_SN_U.h
@@ -5,6 +5,7 @@ class IF44_GER_SN_U {
         uniform = "U_LIB_GER_Soldier_camo_w";
         vest = "fow_v_heer_k98_ARM";
         backpack = "fow_b_heer_aframe";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -41,6 +42,7 @@ class IF44_GER_SN_U {
         vest = "fow_v_heer_g43_ARM";
         uniform = "U_LIB_GER_Scharfschutze_2_w";
         headGear = "H_LIB_GER_Helmet_Medic";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_GER_U.h
+++ b/hull3/assign/uniform/IF44_GER_U.h
@@ -5,6 +5,7 @@ class IF44_GER_U {
         uniform = "U_LIB_GER_Schutze";
         vest = "V_LIB_GER_VestKar98_ARM";
         backpack = "B_LIB_GER_Tonister34_cowhide";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -42,6 +43,7 @@ class IF44_GER_U {
         uniform = "U_LIB_GER_Pionier";
         vest = "V_LIB_GER_VestG43_ARM";
         headGear = "H_LIB_GER_Helmet_net";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_POL_U.h
+++ b/hull3/assign/uniform/IF44_POL_U.h
@@ -5,6 +5,7 @@ class IF44_POL_U {
         uniform = "U_LIB_WP_Soldier_camo_1";
         vest = "fow_v_heer_k98_ARM";
         backpack = "fow_b_heer_aframe";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class IF44_POL_U {
         backpack = "fow_b_tornister_medic";
         uniform = "U_LIB_WP_Soldier_camo_3";
         headGear = "H_LIB_WP_Helmet_med";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_USA_NA_U.h
+++ b/hull3/assign/uniform/IF44_USA_NA_U.h
@@ -5,6 +5,7 @@ class IF44_USA_NA_U {
         uniform = "U_LIB_US_NAC_Uniform_2";
         vest = "V_LIB_US_Vest_Garand_ARM";
         backpack = "B_LIB_US_Backpack";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class IF44_USA_NA_U {
         vest = "V_LIB_US_Vest_Medic2_ARM";
         headgear = "H_LIB_US_Helmet_Med";
         backpack = "B_LIB_US_Backpack";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_USA_PARA_SN_U.H
+++ b/hull3/assign/uniform/IF44_USA_PARA_SN_U.H
@@ -5,6 +5,7 @@ class IF44_USA_PARA_SN_U {
         uniform = "U_LIB_US_AB_Uniform_M42_w";
         vest = "V_LIB_US_AB_Vest_Garand_ARM";
         backpack = "B_LIB_US_M36";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class IF44_USA_PARA_SN_U {
         vest = "V_LIB_US_AB_Vest_Padded_Asst_MG_ARM";
         headgear = "H_LIB_US_AB_Helmet_Clear_3";
         backpack = "B_LIB_US_M36";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_USA_PARA_U.h
+++ b/hull3/assign/uniform/IF44_USA_PARA_U.h
@@ -5,6 +5,7 @@ class IF44_USA_PARA_U {
         uniform = "U_LIB_US_AB_Uniform_M42";
         vest = "V_LIB_US_AB_Vest_Garand_ARM";
         backpack = "B_LIB_US_M36";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class IF44_USA_PARA_U {
         vest = "V_LIB_US_AB_Vest_Padded_Asst_MG_ARM";
         headgear = "H_LIB_US_AB_Helmet_Clear_3";
         backpack = "B_LIB_US_M36";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_USA_SN_U.h
+++ b/hull3/assign/uniform/IF44_USA_SN_U.h
@@ -5,6 +5,7 @@ class IF44_USA_SN_U {
         uniform = "U_LIB_US_Private_w";
         vest = "V_LIB_US_Vest_Garand_ARM";
         backpack = "B_LIB_US_Backpack";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class IF44_USA_SN_U {
         vest = "V_LIB_US_Vest_Medic2_ARM";
         headgear = "H_LIB_US_Helmet_Med_w";
         backpack = "B_LIB_US_Backpack";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_USA_U.h
+++ b/hull3/assign/uniform/IF44_USA_U.h
@@ -5,6 +5,7 @@ class IF44_USA_U {
         uniform = "U_LIB_US_Private";
         vest = "V_LIB_US_Vest_Garand_ARM";
         backpack = "B_LIB_US_Backpack";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -40,6 +41,7 @@ class IF44_USA_U {
         vest = "V_LIB_US_Vest_Medic2_ARM";
         headgear = "H_LIB_US_Helmet_Med";
         backpack = "B_LIB_US_Backpack";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_USSR_NKVD_U.h
+++ b/hull3/assign/uniform/IF44_USSR_NKVD_U.h
@@ -5,6 +5,7 @@ class IF44_USSR_NKVD_U {
         uniform = "U_LIB_NKVD_Efreitor";
         vest = "V_LIB_SOV_RA_MosinBelt_ARM";
         backpack = "B_LIB_SOV_RA_Shinel";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -42,6 +43,7 @@ class IF44_USSR_NKVD_U {
         uniform = "U_LIB_NKVD_Efreitor";
         vest = "V_LIB_SOV_RA_SVTBelt_ARM";
         headGear = "H_LIB_SOV_RA_Helmet";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_USSR_SN_U.h
+++ b/hull3/assign/uniform/IF44_USSR_SN_U.h
@@ -5,6 +5,7 @@ class IF44_USSR_SN_U {
         uniform = "U_LIB_SOV_Strelok_w";
         vest = "V_LIB_SOV_RA_MosinBelt_ARM";
         backpack = "B_LIB_SOV_RA_Shinel";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -42,6 +43,7 @@ class IF44_USSR_SN_U {
         uniform = "U_LIB_SOV_Strelok_w";
         vest = "V_LIB_SOV_RA_SVTBelt_ARM";
         headGear = "H_LIB_SOV_RA_Helmet_w";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IF44_USSR_U.h
+++ b/hull3/assign/uniform/IF44_USSR_U.h
@@ -5,6 +5,7 @@ class IF44_USSR_U {
         uniform = "U_LIB_SOV_Strelok";
         vest = "V_LIB_SOV_RA_MosinBelt_ARM";
         backpack = "B_LIB_SOV_RA_Shinel";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -42,6 +43,7 @@ class IF44_USSR_U {
         uniform = "U_LIB_SOV_Efreitor";
         vest = "V_LIB_SOV_RA_SVTBelt_ARM";
         headGear = "H_LIB_SOV_RA_Helmet";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IRE_DE.h
+++ b/hull3/assign/uniform/IRE_DE.h
@@ -5,6 +5,7 @@ class IRE_DE {
         uniform = "MNP_CombatUniform_Ireland_D";
         vest = "MNP_Vest_Ireland_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class IRE_DE {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IRE_WD.h
+++ b/hull3/assign/uniform/IRE_WD.h
@@ -5,6 +5,7 @@ class IRE_WD {
         uniform = "MNP_CombatUniform_Ireland";
         vest = "MNP_Vest_Ireland_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class IRE_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IRN_ARMY.h
+++ b/hull3/assign/uniform/IRN_ARMY.h
@@ -5,6 +5,7 @@ class IRN_ARMY {
         uniform = "MNP_CombatUniform_IR_IRGC_A";
         vest = "CUP_V_O_SLA_M23_1_BRN_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class IRN_ARMY {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/IRN_RG.h
+++ b/hull3/assign/uniform/IRN_RG.h
@@ -5,6 +5,7 @@ class IRN_RG {
         uniform = "MNP_CombatUniform_IR_BSJ_A";
         vest = "CUP_V_O_SLA_M23_1_BRN_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class IRN_RG {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/LDF.h
+++ b/hull3/assign/uniform/LDF.h
@@ -5,6 +5,7 @@ class LDF {
         uniform = "U_I_E_Uniform_01_F";
         vest = "V_CarrierRigKBT_01_light_EAF_F_ARM";
         backpack = "B_AssaultPack_eaf_F";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class LDF {
     class Medic : Rifleman {
         backpack = "B_Carryall_eaf_F";
         uniform = "U_I_E_Uniform_01_shortsleeve_F";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/LDF_90_SN.h
+++ b/hull3/assign/uniform/LDF_90_SN.h
@@ -5,6 +5,7 @@ class LDF_90_SN {
         uniform = "CUP_U_B_BDUv2_Winter";
         vest = "CUP_V_B_PASGT_winter_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class LDF_90_SN {
     class Medic : Rifleman {
         uniform = "CUP_U_B_BDUv2_gloves_Winter";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/LDF_90_WD.h
+++ b/hull3/assign/uniform/LDF_90_WD.h
@@ -5,6 +5,7 @@ class LDF_90_WD {
         uniform = "CUP_U_B_BDUv2_ERDL_highland";
         vest = "CUP_V_B_PASGT_OD_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class LDF_90_WD {
     class Medic : Rifleman {
         uniform = "CUP_U_B_BDUv2_roll2_gloves_ERDL_highland";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/LVM_DE.h
+++ b/hull3/assign/uniform/LVM_DE.h
@@ -5,6 +5,7 @@ class LVM_DE {
         uniform = "MNP_CombatUniform_Militia_DF";
         vest = "CUP_V_O_SLA_M23_1_BRN_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -37,6 +38,7 @@ class LVM_DE {
         backpack = "ark_backpack_large";
         uniform = "MNP_CombatUniform_Militia_DE";
         headGear = "H_Booniehat_tan";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/LVM_WD.h
+++ b/hull3/assign/uniform/LVM_WD.h
@@ -5,6 +5,7 @@ class LVM_WD {
         uniform = "MNP_CombatUniform_Militia_E";
         vest = "CUP_V_O_SLA_M23_1_OD_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -38,6 +39,7 @@ class LVM_WD {
         backpack = "ark_backpack_large";
         uniform = "MNP_CombatUniform_Militia_F";
         headGear = "H_Booniehat_oli";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/NK_CON.h
+++ b/hull3/assign/uniform/NK_CON.h
@@ -5,6 +5,7 @@ class NK_CON {
         uniform = "MNP_CombatUniform_NKR_Rg";
         vest = "CUP_V_O_SLA_Flak_Vest03_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class NK_CON {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/NK_REG.h
+++ b/hull3/assign/uniform/NK_REG.h
@@ -5,6 +5,7 @@ class NK_REG {
         uniform = "MNP_CombatUniform_NKC_Rg";
         vest = "CUP_V_O_SLA_Flak_Vest03_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class NK_REG {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/NOR_DE.h
+++ b/hull3/assign/uniform/NOR_DE.h
@@ -5,6 +5,7 @@ class NOR_DE {
         uniform = "MNP_CombatUniform_NOR_D_A";
         vest = "MNP_Vest_NOR_D_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class NOR_DE {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/NOR_WD.h
+++ b/hull3/assign/uniform/NOR_WD.h
@@ -5,6 +5,7 @@ class NOR_WD {
         uniform = "MNP_CombatUniform_NOR_A";
         vest = "MNP_Vest_NOR_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class NOR_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/NZ.h
+++ b/hull3/assign/uniform/NZ.h
@@ -5,6 +5,7 @@ class NZ {
         uniform = "MNP_CombatUniform_NZ_A";
         vest = "MNP_Vest_NZ_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class NZ {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/PMC_CBRN.h
+++ b/hull3/assign/uniform/PMC_CBRN.h
@@ -5,6 +5,7 @@ class PMC_CBRN {
         uniform = "U_C_CBRN_Suit_01_Black_F";
         vest = "CUP_V_PMC_CIRAS_Black_Patrol_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -35,6 +36,7 @@ class PMC_CBRN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/ROK_SEAL.h
+++ b/hull3/assign/uniform/ROK_SEAL.h
@@ -5,6 +5,7 @@ class ROK_SEAL {
         uniform = "MNP_CombatUniform_ROKMC";
         vest = "MNP_Vest_ROKMC_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -31,6 +32,7 @@ class ROK_SEAL {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/ROK_WD.h
+++ b/hull3/assign/uniform/ROK_WD.h
@@ -5,6 +5,7 @@ class ROK_WD {
         uniform = "MNP_CombatUniform_ROK_A";
         vest = "MNP_Vest_ROK_2_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -33,6 +34,7 @@ class ROK_WD {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/RU_AB.h
+++ b/hull3/assign/uniform/RU_AB.h
@@ -5,6 +5,7 @@ class RU_AB {
         uniform = "MNP_CombatUniform_RO3_Rg";
         vest = "CUP_V_RUS_Smersh_New_Buttpack_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -34,6 +35,7 @@ class RU_AB {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/RU_CBRN.h
+++ b/hull3/assign/uniform/RU_CBRN.h
@@ -5,6 +5,7 @@ class RU_CBRN {
         uniform = "U_C_CBRN_Suit_01_Blue_F";
         vest = "CUP_V_RUS_6B45_1_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -31,6 +32,7 @@ class RU_CBRN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/SYND_BANDIT.h
+++ b/hull3/assign/uniform/SYND_BANDIT.h
@@ -5,6 +5,7 @@ class SYND_BANDIT {
         uniform = "U_I_C_Soldier_Bandit_5_F";
         vest = "CUP_V_RUS_Smersh_New_Buttpack_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -44,6 +45,7 @@ class SYND_BANDIT {
         uniform = "U_I_C_Soldier_Bandit_1_F";
         vest = "CUP_V_OI_TKI_Jacket2_01_ARM";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/SYND_REBEL.h
+++ b/hull3/assign/uniform/SYND_REBEL.h
@@ -5,6 +5,7 @@ class SYND_REBEL {
         uniform = "U_I_C_Soldier_Para_1_F";
         vest = "CUP_V_RUS_Smersh_New_Buttpack_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -39,6 +40,7 @@ class SYND_REBEL {
     class Medic : Rifleman {
         headGear = "H_Bandanna_sgg";
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/UKR_TTSKO.h
+++ b/hull3/assign/uniform/UKR_TTSKO.h
@@ -5,6 +5,7 @@ class UKR_TTSKO {
         uniform = "MNP_CombatUniform_Ukrainian";
         vest = "MNP_Vest_UKR_A_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class UKR_TTSKO {
         backpack = "ark_backpack_large";
         uniform = "MNP_CombatUniform_Ukrainian";
         goggles = "";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USMC_SN.h
+++ b/hull3/assign/uniform/USMC_SN.h
@@ -5,6 +5,7 @@ class USMC_SN {
         uniform = "MNP_CombatUniform_USMC_arctic";
         vest = "V_PlateCarrier1_blk_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USMC_SN {
 
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_RAN_90_WD.h
+++ b/hull3/assign/uniform/USM_RAN_90_WD.h
@@ -5,6 +5,7 @@ class USM_RAN_90_WD {
         uniform = "usm_bdu_w";
         vest = "usm_vest_rba_lbv_rm_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_RAN_90_WD {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_rba_lbv_rm_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USA_70_OD.h
+++ b/hull3/assign/uniform/USM_USA_70_OD.h
@@ -5,6 +5,7 @@ class USM_USA_70_OD {
         uniform = "usm_bdu_odg";
         vest = "usm_vest_LBE_rm_m_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USA_70_OD {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_LBE_rm_m_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USA_80_CC_DE.h
+++ b/hull3/assign/uniform/USM_USA_80_CC_DE.h
@@ -5,6 +5,7 @@ class USM_USA_80_CC_DE {
         uniform = "usm_bdu_d";
         vest = "usm_vest_pasgtdes_lbe_rm_m_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USA_80_CC_DE {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_pasgtdes_lbe_rm_m_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USA_80_WD.h
+++ b/hull3/assign/uniform/USM_USA_80_WD.h
@@ -5,6 +5,7 @@ class USM_USA_80_WD {
         uniform = "usm_bdu_w";
         vest = "usm_vest_pasgt_lbe_rm_m_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USA_80_WD {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_pasgt_lbe_rm_m_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USA_90_DE.h
+++ b/hull3/assign/uniform/USM_USA_90_DE.h
@@ -5,6 +5,7 @@ class USM_USA_90_DE {
         uniform = "usm_bdu_dcu";
         vest = "usm_vest_pasgtdcu_lbv_rm_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USA_90_DE {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_pasgtdcu_lbv_rm_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USA_90_WD.h
+++ b/hull3/assign/uniform/USM_USA_90_WD.h
@@ -5,6 +5,7 @@ class USM_USA_90_WD {
         uniform = "usm_bdu_w";
         vest = "usm_vest_pasgt_lbv_rm_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USA_90_WD {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_pasgt_lbv_rm_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USMC_80_CC_DE.h
+++ b/hull3/assign/uniform/USM_USMC_80_CC_DE.h
@@ -5,6 +5,7 @@ class USM_USMC_80_CC_DE {
         uniform = "usm_bdu_d_m";
         vest = "usm_vest_pasgtdes_lbe_rm_m_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USMC_80_CC_DE {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_pasgtdes_lbe_rm_m_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USMC_80_WD.h
+++ b/hull3/assign/uniform/USM_USMC_80_WD.h
@@ -5,6 +5,7 @@ class USM_USMC_80_WD {
         uniform = "usm_bdu_w_m";
         vest = "usm_vest_pasgt_lbe_rm_m_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USMC_80_WD {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_pasgt_lbe_rm_m_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USMC_90_DE.h
+++ b/hull3/assign/uniform/USM_USMC_90_DE.h
@@ -5,6 +5,7 @@ class USM_USMC_90_DE {
         uniform = "usm_bdu_dcu_m";
         vest = "usm_vest_pasgtdcu_lbv_rm_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USMC_90_DE {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_pasgtdcu_lbv_rm_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/assign/uniform/USM_USMC_90_WD.h
+++ b/hull3/assign/uniform/USM_USMC_90_WD.h
@@ -5,6 +5,7 @@ class USM_USMC_90_WD {
         uniform = "usm_bdu_w_m";
         vest = "usm_vest_pasgt_lbv_rm_ARM";
         backpack = "ark_backpack_med";
+        insignia = "";
     };
 
     class Leader : Rifleman {
@@ -36,6 +37,7 @@ class USM_USMC_90_WD {
     class Medic : Rifleman {
         backpack = "ark_backpack_large";
         vest = "usm_vest_pasgt_lbv_rm_ARM";
+        insignia = "";
     };
 
     class FTL : Leader {

--- a/hull3/uniform_functions.sqf
+++ b/hull3/uniform_functions.sqf
@@ -122,8 +122,8 @@ hull3_uniform_fnc_assignInsignia = {
     params ["_unit", "_insignia"];
 
     if (_insignia != "") then {
-        // BI says this works globally but thats a lie (April 22)
-        [_unit, _insignia] remoteExec ["BIS_fnc_setUnitInsignia", 0];
+        // Wait 1 frame as cmd uses setObjectTextureGlobal which needs to be in postInit to work
+        [{[_this #0, _this #1] call BIS_fnc_setUnitInsignia}, [_unit, _insignia]] call CBA_fnc_execNextFrame;
         TRACE("hull3.uniform.assign",FMT_2("Assigned insignia '%1' to unit '%2'.",_insignia,_unit));
     };
 };

--- a/hull3/uniform_functions.sqf
+++ b/hull3/uniform_functions.sqf
@@ -122,7 +122,8 @@ hull3_uniform_fnc_assignInsignia = {
     params ["_unit", "_insignia"];
 
     if (_insignia != "") then {
-        [_unit, _insignia] call BIS_fnc_setUnitInsignia;
+        // BI says this works globally but thats a lie (April 22)
+        [_unit, _insignia] remoteExec ["BIS_fnc_setUnitInsignia", -2];
         TRACE("hull3.uniform.assign",FMT_2("Assigned insignia '%1' to unit '%2'.",_insignia,_unit));
     };
 };

--- a/hull3/uniform_functions.sqf
+++ b/hull3/uniform_functions.sqf
@@ -44,7 +44,8 @@ hull3_uniform_fnc_assignUniformTemplate = {
         ["goggles",                 CONFIG_TYPE_TEXT,   hull3_uniform_fnc_assignGoggles],
         ["uniform",                 CONFIG_TYPE_TEXT,   hull3_uniform_fnc_assignUniform],
         ["vest",                    CONFIG_TYPE_TEXT,   hull3_uniform_fnc_assignVest],
-        ["backpack",                CONFIG_TYPE_TEXT,   hull3_uniform_fnc_assignBackpack]
+        ["backpack",                CONFIG_TYPE_TEXT,   hull3_uniform_fnc_assignBackpack],
+        ["insignia",                CONFIG_TYPE_TEXT,   hull3_uniform_fnc_assignInsignia]
     ];
     [_unit, _gearTemplate, _uniformTemplate, _gearClass, _assignables] call hull3_uniform_fnc_assignObjectTemplate;
     DEBUG("hull3.uniform.assign",FMT_3("Assigned uniform class '%1' from template '%2' to unit '%3'.",_gearClass,_uniformTemplate,_unit));
@@ -114,5 +115,14 @@ hull3_uniform_fnc_assignBackpack = {
     if (_backpack != "") then {
         _unit addBackpack _backpack;
         TRACE("hull3.uniform.assign",FMT_2("Assigned backpack '%1' to unit '%2'.",_backpack,_unit));
+    };
+};
+
+hull3_uniform_fnc_assignInsignia = {
+    params ["_unit", "_insignia"];
+
+    if (_insignia != "") then {
+        [_unit, _insignia] call BIS_fnc_setUnitInsignia;
+        TRACE("hull3.uniform.assign",FMT_2("Assigned insignia '%1' to unit '%2'.",_insignia,_unit));
     };
 };

--- a/hull3/uniform_functions.sqf
+++ b/hull3/uniform_functions.sqf
@@ -123,7 +123,7 @@ hull3_uniform_fnc_assignInsignia = {
 
     if (_insignia != "") then {
         // BI says this works globally but thats a lie (April 22)
-        [_unit, _insignia] remoteExec ["BIS_fnc_setUnitInsignia", -2];
+        [_unit, _insignia] remoteExec ["BIS_fnc_setUnitInsignia", 0];
         TRACE("hull3.uniform.assign",FMT_2("Assigned insignia '%1' to unit '%2'.",_insignia,_unit));
     };
 };


### PR DESCRIPTION
Add support for insignia's in the uniform templates. e.g. https://i.imgur.com/uZ87PAf.jpg

- [x] Works in MP/JIP
- [x] Added to all the default templates (blank for now)
- [x] Doesn't error/fail if entry isn't supplied (e.g. on mission with a custom template that is missing `insignia` defined)