### PR TITLE
enableEnvironment setting fix

### DIFF
--- a/hull3/settings_functions.sqf
+++ b/hull3/settings_functions.sqf
@@ -30,6 +30,9 @@ hull3_settings_fnc_setNonStandardGeneralSettings = {
     if (!(["General", "enableEnvironment"] call hull3_config_fnc_getBool)) then {
         [{time > 0}, {enableEnvironment [false, true];}] call CBA_fnc_waitUntilAndExecute;
         DEBUG("hull3.settings","Ambient animals are disabled.");
+    } else {
+        [{time > 0}, {enableEnvironment [true, true];}] call CBA_fnc_waitUntilAndExecute;
+        DEBUG("hull3.settings","Ambient animals are enabled.");
     };
     if (["General", "fadeEnvironment"] call hull3_config_fnc_getBool) then {
         5 fadeEnvironment 0.35;


### PR DESCRIPTION
For some odd reason, if you don't run any `enableEnvironment` commands, it remembers what you'd previously used. I assume it's storing it in userProfile or something (like a graphics setting).

This just manually sets it each time so it actually works if you want to enable them (previously it remained off regardless of Hull setting).