### PR TITLE
Improve hull3_gear_fnc_tryRemoveNightGear

### DIFF
--- a/hull3/gear_functions.sqf
+++ b/hull3/gear_functions.sqf
@@ -333,9 +333,17 @@ hull3_gear_fnc_tryRemoveNightGear = {
 
     private _light = getLighting #1;
     if (_light < 300) exitWith {};
-    DEBUG("hull3.gear.assign.night",FMT_2("Light level below threshold '%1'. Removing night gear from unit '%2'.",_light,_unit));
+    DEBUG("hull3.gear.assign.night",FMT_2("Light level above threshold '%1'. Removing night gear from unit '%2'.",_light,_unit));
 
-    private _chemClasses = ["ACE_Chemlight_HiOrange","ACE_Chemlight_HiRed","ACE_Chemlight_HiYellow","ACE_Chemlight_HiWhite","ACE_Chemlight_Orange","ACE_Chemlight_White","ACE_Chemlight_IR"];
+    private _chemClasses = [
+        "ACE_Chemlight_HiOrange",
+        "ACE_Chemlight_HiRed",
+        "ACE_Chemlight_HiYellow",
+        "ACE_Chemlight_HiWhite",
+        "ACE_Chemlight_Orange",
+        "ACE_Chemlight_White",
+        "ACE_Chemlight_IR"
+    ];
 
     {
         if (_x in _chemClasses) then {

--- a/hull3/gear_functions.sqf
+++ b/hull3/gear_functions.sqf
@@ -332,8 +332,9 @@ hull3_gear_fnc_tryRemoveNightGear = {
     params ["_unit"];
 
     private _light = getLighting #1;
-    if (_light < 300) exitWith {};
-    DEBUG("hull3.gear.assign.night",FMT_2("Light level above threshold '%1'. Removing night gear from unit '%2'.",_light,_unit));
+    private _threshold = ["General", "nightLightLevel"] call hull3_config_fnc_getNumber;
+    if (_light < _threshold) exitWith {};
+    DEBUG("hull3.gear.assign.night",FMT_2("Light level '%1' above threshold '%2'. Removing night gear from unit '%3'.",_light,_threshold,_unit));
 
     private _chemClasses = [
         "ACE_Chemlight_HiOrange",

--- a/hull3/gear_functions.sqf
+++ b/hull3/gear_functions.sqf
@@ -333,7 +333,7 @@ hull3_gear_fnc_tryRemoveNightGear = {
 
     private _light = getLighting #1;
     if (_light < 300) exitWith {};
-    DEBUG("hull3.gear.assign.night",FMT_1("Light level below threshold '%1'. Removing night gear from unit '%2'.",_light,_unit));
+    DEBUG("hull3.gear.assign.night",FMT_2("Light level below threshold '%1'. Removing night gear from unit '%2'.",_light,_unit));
 
     private _chemClasses = ["ACE_Chemlight_HiOrange","ACE_Chemlight_HiRed","ACE_Chemlight_HiYellow","ACE_Chemlight_HiWhite","ACE_Chemlight_Orange","ACE_Chemlight_White","ACE_Chemlight_IR"];
 

--- a/hull3/gear_functions.sqf
+++ b/hull3/gear_functions.sqf
@@ -63,7 +63,9 @@ hull3_gear_fnc_assignUnit = {
     [_unit, _gearTemplate, _uniformTemplate, _gearClass] call hull3_uniform_fnc_assignUniformTemplate;
     [_unit, _faction, _gearTemplate, _gearClass] call hull3_gear_fnc_assignUnitInit;
     [_unit, _gearTemplate, _gearClass] call hull3_gear_fnc_assignUnitTemplate;
-    [_unit] call hull3_gear_fnc_tryRemoveNightGear;
+
+    // Wait to make sure client has time syncd back from server for light value
+    [{time > 10}, {_this call hull3_gear_fnc_tryRemoveNightGear}, [_unit]] call CBA_fnc_waitUntilAndExecute;
 };
 
 hull3_gear_fnc_assignVehicle = {
@@ -329,10 +331,19 @@ hull3_gear_fnc_removeRadios = {
 hull3_gear_fnc_tryRemoveNightGear = {
     params ["_unit"];
 
-    if ([] call hull3_mission_fnc_isNightTime) exitWith {};
-    DEBUG("hull3.gear.assign.night",FMT_1("Removing night gear from unit '%1'.",_unit));
+    private _light = getLighting #1;
+    if (_light < 300) exitWith {};
+    DEBUG("hull3.gear.assign.night",FMT_1("Light level below threshold '%1'. Removing night gear from unit '%2'.",_unit,_light));
+
+    private _chemClasses = ["ACE_Chemlight_HiOrange","ACE_Chemlight_HiRed","ACE_Chemlight_HiYellow","ACE_Chemlight_HiWhite","ACE_Chemlight_Orange","ACE_Chemlight_White","ACE_Chemlight_IR"];
+
     {
-        _unit removeMagazineGlobal _x;
-    } foreach ((magazines _unit) select { _x == "ACE_Chemlight_HiRed" });
-    _unit removeItems "ACE_Flashlight_KSF1";
+        if (_x in _chemClasses) then {
+            _unit removeMagazineGlobal _x;
+        };
+    } forEach magazines _unit;
+
+    {
+        _unit removeItems _x;
+    } forEach ["ACE_Flashlight_MX991","ACE_Flashlight_KSF1","ACE_Flashlight_XL50"];
 };

--- a/hull3/gear_functions.sqf
+++ b/hull3/gear_functions.sqf
@@ -333,7 +333,7 @@ hull3_gear_fnc_tryRemoveNightGear = {
 
     private _light = getLighting #1;
     if (_light < 300) exitWith {};
-    DEBUG("hull3.gear.assign.night",FMT_1("Light level below threshold '%1'. Removing night gear from unit '%2'.",_unit,_light));
+    DEBUG("hull3.gear.assign.night",FMT_1("Light level below threshold '%1'. Removing night gear from unit '%2'.",_light,_unit));
 
     private _chemClasses = ["ACE_Chemlight_HiOrange","ACE_Chemlight_HiRed","ACE_Chemlight_HiYellow","ACE_Chemlight_HiWhite","ACE_Chemlight_Orange","ACE_Chemlight_White","ACE_Chemlight_IR"];
 

--- a/hull3/hull3.h
+++ b/hull3/hull3.h
@@ -89,7 +89,7 @@ class Hull3 {
         #include "assign\uniform\CUP_ION_PMC_SN.h"
         #include "assign\uniform\CUP_ION_PMC.h"
         #include "assign\uniform\PMC_CBRN.h"
-		#include "assign\uniform\FOW_USMC_U.h"
+        #include "assign\uniform\FOW_USMC_U.h"
         #include "assign\uniform\FOW_USA_U.h"
         #include "assign\uniform\FOW_USA_PAC_U.h"
         #include "assign\uniform\FOW_USA_PARA_U.h"
@@ -283,7 +283,6 @@ class Hull3 {
     class Marker {
         isGroupEnabled = 1;
         isFireTeamEnabled = 1;
-
         defaultDelay = 3;
 
         class MedicMarker {
@@ -379,6 +378,7 @@ class Hull3 {
         disableRemoteSensors = 1;                       // Disables RemoteSensors
         enableEnvironment = 0;                          // Disables ambient animals but keeps sounds
         fadeEnvironment = 1;                            // Reduce sound of environmental sounds (rain/thunder/insects)
+        nightLightLevel = 300;                          // getLighting value must be below this to be considered dark and keep night gear
     };
 
     class Logistics {

--- a/hull3/mission_functions.sqf
+++ b/hull3/mission_functions.sqf
@@ -89,15 +89,6 @@ hull3_mission_fnc_getTimeOfDay = {
     (["MissionParams", "time"] call hull3_config_fnc_getArray) select (paramsArray select _paramIdx);
 };
 
-hull3_mission_fnc_isNightTime = {
-    private _nightTimeStart = 17 * 60 + 50;
-    private _nightTimeEnd = 4 * 60;
-    private _timeOfDay = [] call hull3_mission_fnc_getTimeOfDay;
-    private _currentTime = (_timeOfDay #0) * 60 + (_timeOfDay #1);
-
-    _currentTime >= _nightTimeStart || {_currentTime <= _nightTimeEnd};
-};
-
 hull3_mission_fnc_getFog = {
     if (isNil {hull3_mission_fog}) then {
         hull3_mission_fog = [0, 0, 0];


### PR DESCRIPTION
Switched from a hardcoded time function to using `getLighting` which reports a number based on weather/terrain. Means weird terrains like Caribou shouldn't have night gear during the day etc. I removed `hull3_mission_fnc_isNightTime` function as it's only called here and we can just use one command to replace it. Expanded the logging a bit so I can debug it if it does anything weird. The magic number is roughly what I get around 60-45 minutes before it's "dark" on a few terrains, so if you start as the lights fading you'll keep your night equipment.

Expanded the clean up to all ACE chemlights + maplights.

Only thing I don't like is waiting 10 seconds but I couldn't find an event or anything to hook to make sure the client's date/time has been sync'd from the server so I figured 10 seconds is safe enough!