### PR TITLE
Handle dynamicSim AI standing post death

### DIFF
--- a/hull3/gc_functions.sqf
+++ b/hull3/gc_functions.sqf
@@ -91,6 +91,10 @@ hull3_gc_fnc_sortDead = {
 
     if (_killed isKindOf "CAManBase") then {
          hull3_gc_deadUnits pushBack _killed;
+        // Handles killed AI with dynmaicSim in a frozen standing animation post death
+        if !(simulationEnabled _killed) then {
+            _killed enableSimulationGlobal true;
+        };
     } else {
         hull3_gc_deadVehicles pushBack _killed;
     };


### PR DESCRIPTION
If you use `dynamicSimulation` on AI (as we do for CQC/sentries) if they take a fatal amount of damage they still "die" but as simulation is disabled the model remains frozen in a standing animation.

I happened to noticed while testing that the `EntityKilled` EH was still firing on them even though they weren't be actively simulated. This lead to doing some testing and finding that we can use this event to `enableSimulation` on the AI that's died to have it move to ragdoll. This has been a bit of a bugbear since we added this system and is one of the most annoying parts, hopefully fixed!

I wasn't quite sure where this wanted to live as dynamicSim is configured from Admiral but we're already hooking the EH in Hull for GC so I figured it makes more sense to be here.