### PR TITLE
Turn entries in the .RPT-log to structured text

### DIFF
--- a/hull3/acre_functions.sqf
+++ b/hull3/acre_functions.sqf
@@ -275,7 +275,7 @@ hull3_acre_fnc_adminAssignRadio = {
             params ["_unit", "_name", "_radio"];
 
             private _message = format ["Player '%1' in unit '%2' has requested radio '%3'!", _name, _unit, _radio];
-            diag_log LOGGING_FORMAT("hull3.acre.admin","WARN",_message);
+            diag_log text LOGGING_FORMAT("hull3.acre.admin","WARN",_message);
         }] remoteExec ["bis_fnc_call", 2];
     } else {
         systemChat format ["[Hull3] Requested radio '%1' cannot be added to uniform. Make sure you have enough space!", _radio];

--- a/hull3/common_functions.sqf
+++ b/hull3/common_functions.sqf
@@ -8,7 +8,7 @@ hull3_common_fnc_logOnServer = {
     FUN_ARGS_1(_message);
 
     if (isDedicated) then {
-        [0, {diag_log _this}, _message] call CBA_globalExecute;
+        [0, {diag_log text _this}, _message] call CBA_globalExecute;
     };
     if (isServer) then {
         diag_log _message;

--- a/hull3/logbook.h
+++ b/hull3/logbook.h
@@ -43,7 +43,7 @@
 
 #define LB_RPT_LOGGER(MESSG)
 #ifdef LOGGING_TO_RPT
-    #define LB_RPT_LOGGER(MESSG)                diag_log (MESSG)
+    #define LB_RPT_LOGGER(MESSG)                diag_log text (MESSG)
 #endif //LOGGING_TO_RPT
 
 #define LB_CHAT_LOGGER(MESSG)


### PR DESCRIPTION
This will prevent Hull3 log lines getting quotes (") around them, just its CBA and ACE3 peers.

This is a pet-peeve of mine when keeping the .rpt-log open during editing. I see entries like these from ACE, ACRE and CBA:
```
 2:06:00 [ACE] (medical) WARNING:  missing ace hitpoints: []
 2:06:01 [ACRE] (sys_antenna) INFO: Loaded Binary Antenna Data for ACRE_BaseAntenna [\idi\acre\addons\sys_antenna\binary\Thales_100cm_Whip_gain.aba]: 1
 2:06:01 [CBA] (xeh) INFO: [0,70.206,0] PreStart finished.
```

When Hull prints anything it looks like this:
```
 2:06:58 "[ARK] (Admin Tools) - [INFO] - (fnc_initModules) -Created sideLogic group: L Alpha 1-2 with groupName: bis_fnc_initModules_NO_CATEGORY"
 2:06:58 "[ARK] (Admin Tools) - [INFO] - (fnc_initModules) -Created sideLogic group: L Alpha 1-3 with groupName: bis_fnc_initModules_LSR"
```

Looking at how this is done by CBA: https://github.com/CBATeam/CBA_A3/blob/9191ad571f4e31b6e7c8e17a407f0a2b2296d2c8/addons/main/script_macros_common.hpp#L174
And the first comment on the biki: https://community.bistudio.com/wiki/diag_log
So this seems to be a thing.

You can try this setup for yourself locally by executing 
`diag_log "test1234";`
and
`diag_log text "test1234"`
and bashing the server exec button and observing the difference in your active .rpt-log. 